### PR TITLE
feat(web): files/images preview function

### DIFF
--- a/server/internal/handlers/vault_files.go
+++ b/server/internal/handlers/vault_files.go
@@ -202,5 +202,8 @@ func (h *VaultFileHandler) Serve(c echo.Context) error {
 	}
 
 	filePath := filepath.Join(h.vaultFileService.UploadDir(), file.UUID)
+	if c.QueryParam("preview") == "true" && strings.HasPrefix(file.MimeType, "image/") {
+		return c.Inline(filePath, file.Name)
+	}
 	return c.Attachment(filePath, file.Name)
 }

--- a/web/src/pages/vault/VaultFiles.tsx
+++ b/web/src/pages/vault/VaultFiles.tsx
@@ -12,6 +12,7 @@ import {
   Popconfirm,
   App,
   Segmented,
+  Image,
 } from "antd";
 import {
   ArrowLeftOutlined,
@@ -112,19 +113,7 @@ export default function VaultFiles() {
       key: "name",
       render: (name: string, record: Document) => (
         <span style={{ display: "flex", alignItems: "center", gap: 10 }}>
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              borderRadius: token.borderRadius,
-              background: token.colorFillSecondary,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            {getFileIcon(record.mime_type ?? '')}
-          </div>
+          {record.mime_type?.startsWith("image/") ? ( <Image width={36} height={36} src={`/api/vaults/${vaultId}/files/${record.id}/download?token=${localStorage.getItem("token")}&preview=true`} style={{ objectFit: "cover", borderRadius: token.borderRadius }} preview={{ src: `/api/vaults/${vaultId}/files/${record.id}/download?token=${localStorage.getItem("token")}&preview=true` }} /> ) : ( <div style={{ width: 36, height: 36, borderRadius: token.borderRadius, background: token.colorFillSecondary, display: "flex", alignItems: "center", justifyContent: "center", }} > {getFileIcon(record.mime_type ?? '')} </div> )}
           <span style={{ fontWeight: 500 }}>{name}</span>
         </span>
       ),


### PR DESCRIPTION
## Summary
- Fixes #47
- Added inline preview support for images in the VaultFiles list.
- Added `?preview=true` parameter parsing in the backend to serve images inline instead of as attachments.
