### PR TITLE
fix(web): add manage relationship types link in relationship modal

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -696,6 +696,8 @@
       "contact": "Contact",
       "select_contact": "Select a contact",
       "relationship_type": "Relationship Type",
+      "manage_types": "Manage Types",
+      "manage_types_hint": "Configure relationship types, degrees and reverse relationships in Settings",
       "graph_title": "Relationship Network",
       "graph_empty": "No relationships to visualize",
       "kinship_degree": "Kinship Degree: {{degree}}",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -696,6 +696,8 @@
       "contact": "联系人",
       "select_contact": "选择联系人",
       "relationship_type": "关系类型",
+      "manage_types": "管理类型",
+      "manage_types_hint": "在设置中配置关系类型、亲属层级和反向关系",
       "graph_title": "关系网络",
       "graph_empty": "暂无关系可视化",
       "kinship_degree": "亲等度数: {{degree}}",

--- a/web/src/pages/contact/modules/RelationshipsModule.tsx
+++ b/web/src/pages/contact/modules/RelationshipsModule.tsx
@@ -203,6 +203,14 @@ export default function RelationshipsModule({
               options={relationshipTypes.map((rt) => ({ value: rt.id!, label: rt.name ?? "" }))}
             />
           </Form.Item>
+          <div style={{ marginTop: -12, marginBottom: 24 }}>
+            <a onClick={() => window.open("/settings/personalize", "_blank")} style={{ fontSize: 12, color: token.colorPrimary }}>
+              {t("modules.relationships.manage_types")}
+            </a>
+            <div style={{ fontSize: 12, color: token.colorTextSecondary, marginTop: 4 }}>
+              {t("modules.relationships.manage_types_hint")}
+            </div>
+          </div>
         </Form>
       </Modal>
     </Card>


### PR DESCRIPTION
## Summary
- Fixes #35
- Added a convenient link to 'Manage Types' right below the relationship type selector in the Add/Edit Relationship modal.
- This guides users directly to the Personalize settings page where they can configure relationship degrees, inverse relationship names, and create new relationship types.
