### PR TITLE
fix(db): Postgres/SQLite SQL compatibility (fixes #85)

### DIFF
--- a/server/internal/services/admin.go
+++ b/server/internal/services/admin.go
@@ -40,15 +40,21 @@ func (s *AdminService) ListUsers() ([]dto.AdminUserResponse, error) {
 	return result, nil
 }
 
-func (s *AdminService) toAdminUserResponse(u models.User) dto.AdminUserResponse {
-	var contactCount int64
-	// Exclude shadow contacts (can_be_deleted=false AND listed=false) from admin stats
-	s.db.Raw(`
+// adminContactCountSQL counts contacts per account, excluding UserVault shadow
+// contacts (can_be_deleted=false AND listed=false). Parameters: account_id,
+// can_be_deleted, listed.
+func adminContactCountSQL() string {
+	return `
 		SELECT COUNT(DISTINCT c.id)
 		FROM contacts c
 		INNER JOIN vaults v ON c.vault_id = v.id
 		WHERE v.account_id = ?
-		AND NOT (c.can_be_deleted = 0 AND c.listed = 0)`, u.AccountID).Scan(&contactCount)
+		AND NOT (c.can_be_deleted = ? AND c.listed = ?)`
+}
+
+func (s *AdminService) toAdminUserResponse(u models.User) dto.AdminUserResponse {
+	var contactCount int64
+	s.db.Raw(adminContactCountSQL(), u.AccountID, false, false).Scan(&contactCount)
 
 	var vaultCount int64
 	s.db.Model(&models.Vault{}).Where("account_id = ?", u.AccountID).Count(&vaultCount)

--- a/server/internal/services/contact.go
+++ b/server/internal/services/contact.go
@@ -55,10 +55,11 @@ func (s *ContactService) ListContacts(vaultID, userID string, page, perPage int,
 		query = query.Where("listed = ?", true)
 	}
 	if search != "" {
+		like := "%" + strings.ToLower(search) + "%"
 		query = query.Where(
-			s.db.Where("first_name LIKE ?", "%"+search+"%").
-				Or("last_name LIKE ?", "%"+search+"%").
-				Or("nickname LIKE ?", "%"+search+"%"),
+			s.db.Where("LOWER(first_name) LIKE ?", like).
+				Or("LOWER(last_name) LIKE ?", like).
+				Or("LOWER(nickname) LIKE ?", like),
 		)
 	}
 	var total int64
@@ -73,9 +74,7 @@ func (s *ContactService) ListContacts(vaultID, userID string, page, perPage int,
 	}
 	offset := (page - 1) * perPage
 	orderClause := contactSortOrder(sort)
-	// Prepend favorites-first sorting
-	favOrder := "CASE WHEN id IN (SELECT contact_id FROM contact_vault_user WHERE user_id = '" + userID + "' AND is_favorite = 1) THEN 0 ELSE 1 END"
-	finalOrder := favOrder + ", " + orderClause
+	finalOrder := favoriteOrderClause(userID) + ", " + orderClause
 	var contacts []models.Contact
 	if err := query.Offset(offset).Limit(perPage).Order(finalOrder).Find(&contacts).Error; err != nil {
 		return nil, response.Meta{}, err
@@ -334,9 +333,7 @@ func (s *ContactService) ListContactsByLabel(vaultID, userID string, labelID uin
 	}
 	offset := (page - 1) * perPage
 	orderClause := contactSortOrder(sort)
-	// Prepend favorites-first sorting
-	favOrder := "CASE WHEN id IN (SELECT contact_id FROM contact_vault_user WHERE user_id = '" + userID + "' AND is_favorite = 1) THEN 0 ELSE 1 END"
-	finalOrder := favOrder + ", " + orderClause
+	finalOrder := favoriteOrderClause(userID) + ", " + orderClause
 	var contacts []models.Contact
 	if err := query.Offset(offset).Limit(perPage).Order(finalOrder).Find(&contacts).Error; err != nil {
 		return nil, response.Meta{}, err
@@ -375,15 +372,15 @@ func (s *ContactService) QuickSearch(vaultID, term string) ([]dto.ContactSearchI
 		return []dto.ContactSearchItem{}, nil
 	}
 
-	likeTerm := "%" + term + "%"
+	likeTerm := "%" + strings.ToLower(term) + "%"
 	var contacts []models.Contact
 	if err := s.db.Where("vault_id = ?", vaultID).
 		Where(
-			s.db.Where("first_name LIKE ?", likeTerm).
-				Or("last_name LIKE ?", likeTerm).
-				Or("nickname LIKE ?", likeTerm).
-				Or("maiden_name LIKE ?", likeTerm).
-				Or("middle_name LIKE ?", likeTerm),
+			s.db.Where("LOWER(first_name) LIKE ?", likeTerm).
+				Or("LOWER(last_name) LIKE ?", likeTerm).
+				Or("LOWER(nickname) LIKE ?", likeTerm).
+				Or("LOWER(maiden_name) LIKE ?", likeTerm).
+				Or("LOWER(middle_name) LIKE ?", likeTerm),
 		).
 		Order("first_name ASC, last_name ASC").
 		Limit(5).
@@ -436,6 +433,10 @@ func strPtrOrNil(s string) *string {
 		return nil
 	}
 	return &s
+}
+
+func favoriteOrderClause(userID string) string {
+	return "CASE WHEN id IN (SELECT contact_id FROM contact_vault_user WHERE user_id = '" + userID + "' AND is_favorite = true) THEN 0 ELSE 1 END"
 }
 
 func contactSortOrder(sort string) string {

--- a/server/internal/services/contact_postgres_compat_test.go
+++ b/server/internal/services/contact_postgres_compat_test.go
@@ -1,0 +1,90 @@
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/naiba/bonds/internal/dto"
+	"github.com/naiba/bonds/internal/models"
+	"github.com/naiba/bonds/internal/testutil"
+	"gorm.io/gorm"
+)
+
+// Regression tests for https://github.com/naiba/bonds/issues/85:
+// PostgreSQL rejects `boolean_column = 1` with
+// "operator does not exist: boolean = integer". SQLite accepts it, so these
+// tests inspect the generated SQL instead of executing against Postgres.
+
+func TestFavoriteOrderClauseIsPostgresCompatible(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	cfg := testutil.TestJWTConfig()
+	authSvc := NewAuthService(db, cfg)
+	vaultSvc := NewVaultService(db)
+	contactSvc := NewContactService(db)
+
+	resp, err := authSvc.Register(dto.RegisterRequest{
+		FirstName: "Test", LastName: "User",
+		Email: "pg-compat@example.com", Password: "password123",
+	}, "en")
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	vault, err := vaultSvc.CreateVault(resp.User.AccountID, resp.User.ID, dto.CreateVaultRequest{Name: "V"}, "en")
+	if err != nil {
+		t.Fatalf("CreateVault failed: %v", err)
+	}
+	if _, err := contactSvc.CreateContact(vault.ID, resp.User.ID, dto.CreateContactRequest{FirstName: "Alice"}); err != nil {
+		t.Fatalf("CreateContact failed: %v", err)
+	}
+
+	dryDB := db.Session(&gorm.Session{DryRun: true})
+	stmt := dryDB.Model(&models.Contact{}).
+		Where("vault_id = ? AND NOT (can_be_deleted = ? AND listed = ?)", vault.ID, false, false).
+		Where("listed = ?", true).
+		Order(favoriteOrderClause(resp.User.ID) + ", first_name ASC, last_name ASC").
+		Find(&[]models.Contact{}).Statement
+
+	sql := strings.ToLower(stmt.SQL.String())
+	if strings.Contains(sql, "is_favorite = 1") || strings.Contains(sql, "is_favorite = 0") {
+		t.Errorf("ORDER BY compares boolean is_favorite against integer literal; SQL: %s", sql)
+	}
+
+	if _, _, err := NewContactService(dryDB).ListContacts(vault.ID, resp.User.ID, 1, 15, "", "first_name", ""); err != nil {
+		t.Fatalf("ListContacts (dry-run) failed: %v", err)
+	}
+}
+
+func TestFavoriteOrderClauseStringIsPostgresCompatible(t *testing.T) {
+	clause := favoriteOrderClause("some-user-id")
+	if strings.Contains(clause, "is_favorite = 1") || strings.Contains(clause, "is_favorite = 0") {
+		t.Errorf("favoriteOrderClause uses integer literal, breaks PostgreSQL: %s", clause)
+	}
+}
+
+func TestAdminContactCountRawSQLIsPostgresCompatible(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	cfg := testutil.TestJWTConfig()
+	authSvc := NewAuthService(db, cfg)
+	adminSvc := NewAdminService(db, t.TempDir())
+
+	resp, err := authSvc.Register(dto.RegisterRequest{
+		FirstName: "Test", LastName: "User",
+		Email: "pg-admin@example.com", Password: "password123",
+	}, "en")
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	dryDB := db.Session(&gorm.Session{DryRun: true})
+	var contactCount int64
+	stmt := dryDB.Raw(adminContactCountSQL(), resp.User.AccountID, false, false).Scan(&contactCount).Statement
+
+	sql := strings.ToLower(stmt.SQL.String())
+	if strings.Contains(sql, "can_be_deleted = 0") || strings.Contains(sql, "listed = 0") {
+		t.Errorf("admin contact-count SQL compares boolean against integer literal; SQL: %s", sql)
+	}
+
+	if _, err := adminSvc.ListUsers(); err != nil {
+		t.Fatalf("ListUsers failed: %v", err)
+	}
+}

--- a/server/internal/services/contact_search_case_insensitive_test.go
+++ b/server/internal/services/contact_search_case_insensitive_test.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/naiba/bonds/internal/dto"
+	"github.com/naiba/bonds/internal/testutil"
+)
+
+// SQLite LIKE is case-insensitive by default; PostgreSQL LIKE is
+// case-sensitive. Contact name search must behave identically on both, so the
+// source must use LOWER(col) LIKE LOWER(?) (or ILIKE) rather than a bare LIKE.
+// A functional SQLite test would pass without the fix, so we inspect the source
+// directly.
+
+func TestContactSearchUsesCaseInsensitiveLike(t *testing.T) {
+	src, err := os.ReadFile("contact.go")
+	if err != nil {
+		t.Fatalf("read contact.go: %v", err)
+	}
+	content := string(src)
+
+	for _, bare := range []string{
+		`first_name LIKE ?`,
+		`last_name LIKE ?`,
+		`nickname LIKE ?`,
+		`maiden_name LIKE ?`,
+		`middle_name LIKE ?`,
+	} {
+		if strings.Contains(content, bare) {
+			t.Errorf("contact.go uses bare %q - breaks case-insensitive search on PostgreSQL; use LOWER(col) LIKE LOWER(?) instead", bare)
+		}
+	}
+}
+
+func TestContactSearchIsCaseInsensitive(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	cfg := testutil.TestJWTConfig()
+	authSvc := NewAuthService(db, cfg)
+	vaultSvc := NewVaultService(db)
+	contactSvc := NewContactService(db)
+
+	resp, err := authSvc.Register(dto.RegisterRequest{
+		FirstName: "T", LastName: "U",
+		Email: "ci-fn@example.com", Password: "password123",
+	}, "en")
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	vault, err := vaultSvc.CreateVault(resp.User.AccountID, resp.User.ID, dto.CreateVaultRequest{Name: "V"}, "en")
+	if err != nil {
+		t.Fatalf("CreateVault failed: %v", err)
+	}
+	if _, err := contactSvc.CreateContact(vault.ID, resp.User.ID, dto.CreateContactRequest{FirstName: "Alice"}); err != nil {
+		t.Fatalf("CreateContact failed: %v", err)
+	}
+
+	for _, term := range []string{"alice", "ALICE", "AlIcE"} {
+		got, _, err := contactSvc.ListContacts(vault.ID, resp.User.ID, 1, 15, term, "", "")
+		if err != nil {
+			t.Fatalf("ListContacts(%q) failed: %v", term, err)
+		}
+		if len(got) != 1 || got[0].FirstName != "Alice" {
+			t.Errorf("ListContacts(%q) = %v; want 1 match 'Alice'", term, got)
+		}
+
+		qs, err := contactSvc.QuickSearch(vault.ID, term)
+		if err != nil {
+			t.Fatalf("QuickSearch(%q) failed: %v", term, err)
+		}
+		if len(qs) != 1 {
+			t.Errorf("QuickSearch(%q) = %v; want 1 match", term, qs)
+		}
+	}
+}

--- a/server/internal/services/personalize.go
+++ b/server/internal/services/personalize.go
@@ -3,6 +3,7 @@ package services
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/naiba/bonds/internal/dto"
 	"github.com/naiba/bonds/internal/i18n"
@@ -95,9 +96,10 @@ func (s *PersonalizeService) Create(accountID, entity string, req dto.Personaliz
 		val = req.Name
 	}
 
+	now := time.Now()
 	result := s.db.Exec(
-		fmt.Sprintf("INSERT INTO %s (account_id, %s, %s, created_at, updated_at) VALUES (?, ?, ?, NOW(), NOW())", cfg.table, labelCol, nameCol),
-		accountID, val, val,
+		fmt.Sprintf("INSERT INTO %s (account_id, %s, %s, created_at, updated_at) VALUES (?, ?, ?, ?, ?)", cfg.table, labelCol, nameCol),
+		accountID, val, val, now, now,
 	)
 	if result.Error != nil {
 		return nil, result.Error
@@ -122,8 +124,8 @@ func (s *PersonalizeService) Update(accountID, entity string, id uint, req dto.P
 	}
 
 	result := s.db.Exec(
-		fmt.Sprintf("UPDATE %s SET %s = ?, %s = ?, updated_at = NOW() WHERE id = ? AND account_id = ?", cfg.table, labelCol, nameCol),
-		val, val, id, accountID,
+		fmt.Sprintf("UPDATE %s SET %s = ?, %s = ?, updated_at = ? WHERE id = ? AND account_id = ?", cfg.table, labelCol, nameCol),
+		val, val, time.Now(), id, accountID,
 	)
 	if result.Error != nil {
 		return nil, result.Error

--- a/server/internal/services/personalize_create_update_test.go
+++ b/server/internal/services/personalize_create_update_test.go
@@ -1,0 +1,39 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/naiba/bonds/internal/dto"
+)
+
+func TestPersonalizeCreate_WorksOnSQLite(t *testing.T) {
+	svc, accountID := setupPersonalizeTest(t)
+
+	resp, err := svc.Create(accountID, "genders", dto.PersonalizeEntityRequest{Name: "Custom"})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if resp.Name != "Custom" {
+		t.Errorf("expected name 'Custom', got %q", resp.Name)
+	}
+	if resp.CreatedAt.IsZero() {
+		t.Errorf("expected CreatedAt to be set")
+	}
+}
+
+func TestPersonalizeUpdate_WorksOnSQLite(t *testing.T) {
+	svc, accountID := setupPersonalizeTest(t)
+
+	created, err := svc.Create(accountID, "genders", dto.PersonalizeEntityRequest{Name: "Before"})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	updated, err := svc.Update(accountID, "genders", created.ID, dto.PersonalizeEntityRequest{Name: "After"})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if updated.Name != "After" {
+		t.Errorf("expected name 'After', got %q", updated.Name)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #85 (contacts page 500 on Postgres) and three sibling dialect-compat bugs surfaced by the audit.

## Bugs fixed

| File | Bug | Effect |
|---|---|---|
| `server/internal/services/contact.go` | favorite `ORDER BY` used `is_favorite = 1` | Postgres: `operator does not exist: boolean = integer` → contacts page 500 |
| `server/internal/services/admin.go` | admin contact-count raw SQL used `can_be_deleted = 0 AND listed = 0` | Postgres: admin users page 500 |
| `server/internal/services/personalize.go` | `Create`/`Update` wrote `NOW()` in raw SQL | SQLite: `no such function: NOW` → every personalize entity create/update failed silently (no test coverage) |
| `server/internal/services/contact.go` | bare `LIKE` for contact search | Postgres: name search became case-sensitive (e.g. "alice" no longer matched "Alice"). Now uses `LOWER(col) LIKE LOWER(?)` on both dialects. |

## TDD

Each fix has a regression test (RED verified before GREEN):
- `contact_postgres_compat_test.go` — dry-run SQL inspection for boolean-vs-integer
- `personalize_create_update_test.go` — functional SQLite test for `NOW()` regression
- `contact_search_case_insensitive_test.go` — source-level + functional tests for case-insensitive search

## Verification

- `go test ./... -count=1` → 1207/1207 passed (19 packages, +7 new tests)
- `go vet ./...` → clean

## Out of scope (flagged but not changed)

- `contact.go:favoriteOrderClause` still string-concatenates `userID` into raw SQL. Low risk (userID from validated JWT claim); refactor would need `clause.Expr` rewiring. Tracked separately if desired.