### PR TITLE
fix(ui): tighten consistency in navbar, empty states, and contact list

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -215,7 +215,7 @@ export default function Layout() {
           </div>
 
           {/* Right side: actions — hidden on mobile when search is expanded */}
-          <div style={{ display: "flex", alignItems: "center", gap: 4, flexShrink: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
             <Tooltip title={themeModeLabels[themeMode]}>
               <Button type="text" size="small" icon={themeModeIcons[themeMode]} onClick={nextThemeMode} />
             </Tooltip>
@@ -241,7 +241,6 @@ export default function Layout() {
                   cursor: "pointer",
                   display: "flex",
                   alignItems: "center",
-                  marginLeft: 4,
                   padding: "2px 4px",
                   borderRadius: token.borderRadius,
                 }}
@@ -266,7 +265,7 @@ export default function Layout() {
               padding: "0 16px",
               display: "flex",
               alignItems: "center",
-              gap: 2,
+              gap: 4,
               height: 52,
               overflowX: "auto",
             }}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -359,7 +359,15 @@ html[data-theme="dark"] .bonds-search-dropdown {
   font-family: 'Playfair Display', serif;
   font-size: 22px;
   font-weight: 600;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
+  line-height: 1.3;
+}
+
+.bonds-empty-hero-desc {
+  font-size: 14px;
+  line-height: 1.6;
+  max-width: 360px;
+  margin: 0 auto 24px;
 }
 
 /* Scrollbar styling */

--- a/web/src/pages/contact/ContactList.tsx
+++ b/web/src/pages/contact/ContactList.tsx
@@ -297,10 +297,9 @@ export default function ContactList() {
                 }
               }}
             >
-              <Button size="small" icon={<UploadOutlined />}>{t("vcard.import")}</Button>
+              <Button icon={<UploadOutlined />}>{t("vcard.import")}</Button>
             </Upload>
             <Button
-              size="small"
               icon={<DownloadOutlined />}
               onClick={async () => {
                 try {
@@ -337,10 +336,7 @@ export default function ContactList() {
           value={search}
           onChange={(e) => handleSearch(e.target.value)}
           allowClear
-          style={{
-            maxWidth: 300,
-            borderRadius: 20,
-          }}
+          style={{ maxWidth: 300 }}
         />
         <Select
             placeholder={t("contact.list.sort_by")}


### PR DESCRIPTION
## Summary

Small, surgical pass over a few visible inconsistencies I noticed while exploring the app for the first time. Three files, +13/-10.

### Changes

**`web/src/components/Layout.tsx`**
- Header right-side actions: `gap: 4 → 8`, and dropped a redundant `marginLeft: 4` on the avatar wrapper that was compounding with the gap. The theme/language buttons now breathe evenly with the avatar.
- Vault nav within-group `gap: 2 → 4`. The dividers (`margin: 0 6px`) still read as group separators, but adjacent pills inside a group no longer feel cramped.

**`web/src/index.css`**
- Added a `.bonds-empty-hero-desc` rule. The class is referenced from JSX in several pages (Groups, Reminders, Tasks, Files, Companies) but had no CSS, so the description text butted up against the CTA button with no margin and no max-width.
- Bumped `.bonds-empty-hero-title` `margin-bottom: 8 → 12` for clearer title→description rhythm.

**`web/src/pages/contact/ContactList.tsx`**
- Removed `size=\"small\"` from the Import and Export All buttons so all three header buttons (Import, Export All, Add contact) share one size. The primary CTA is differentiated by color and icon, not size.
- Removed `borderRadius: 20` from the Quick search input so it stops being the only pill-shaped control in a row of standard-radius Selects.

### Test plan

- [x] `bun run lint` — eslint + i18n key consistency check pass
- [x] `bun run build` — tsc + vite build succeed
- [x] `bun run test` — 130/130 pass
- [ ] Manual: navbar spacing, Groups empty state, Contacts list filter row

### Notes

Marked draft because I'd like a maintainer eye on whether button-size consistency in `ContactList` should go the other way (make Add contact `size=\"small\"` to match) — I picked default size for all three because primary CTAs typically read better that way, but happy to flip if the project prefers small everywhere.