### PR TITLE
fix(theme): selected tab text and focus ring readable in dark mode

### DIFF
--- a/web/src/ThemedApp.tsx
+++ b/web/src/ThemedApp.tsx
@@ -57,6 +57,9 @@ export default function ThemedApp() {
                 colorBgContainer: "rgba(18, 22, 19, 0.75)",
                 colorBgElevated: "rgba(24, 30, 26, 0.95)",
                 colorTextBase: "rgba(255, 255, 255, 0.9)",
+                colorTextSecondary: "rgba(255, 255, 255, 0.65)",
+                colorTextTertiary: "rgba(255, 255, 255, 0.45)",
+                colorTextQuaternary: "rgba(255, 255, 255, 0.25)",
                 colorBorder: "rgba(255, 255, 255, 0.08)",
               }
             : {
@@ -64,6 +67,9 @@ export default function ThemedApp() {
                 colorBgContainer: "rgba(255, 255, 255, 0.8)",
                 colorBgElevated: "rgba(255, 255, 255, 0.98)",
                 colorTextBase: "rgba(0, 0, 0, 0.85)",
+                colorTextSecondary: "rgba(0, 0, 0, 0.65)",
+                colorTextTertiary: "rgba(0, 0, 0, 0.45)",
+                colorTextQuaternary: "rgba(0, 0, 0, 0.25)",
                 colorBorder: "rgba(0, 0, 0, 0.08)",
               }),
         },
@@ -98,7 +104,14 @@ export default function ThemedApp() {
             controlHeight: 42,
           },
           Tabs: {
-            itemSelectedColor: "#3b6347",
+            // Selected text color must read against the tab background.
+            // The brand green (#3b6347) is too dark on dark mode's container,
+            // so use the resolved text color in dark mode while keeping the
+            // brand accent in light mode where it works.
+            itemSelectedColor:
+              resolvedTheme === "dark"
+                ? "rgba(255, 255, 255, 0.95)"
+                : "#3b6347",
             inkBarColor: "#3b6347",
             titleFontSizeLG: 16,
           },

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -402,6 +402,8 @@ html[data-theme="dark"] .ant-input, html[data-theme="dark"] .ant-input-password,
 }
 
 html[data-theme="dark"] .ant-input:focus, html[data-theme="dark"] .ant-input-focused, html[data-theme="dark"] .ant-select-focused .ant-select-selector {
+  border-color: #7ec496 !important;
+  box-shadow: 0 0 0 3px rgba(126, 196, 150, 0.25) !important;
   background-color: #1a1e1b !important;
 }
 


### PR DESCRIPTION
## Summary

Three targeted fixes for the most readability-critical color/contrast issues. Two files, +16/-1.

### Changes

**\`web/src/ThemedApp.tsx\`**
- \`Tabs.itemSelectedColor\` was hardcoded to \`#3b6347\` (brand green). In dark mode this puts dark-green text on the dark \`colorBgContainer\` — effectively invisible. Branch on \`resolvedTheme\`: keep the brand green in light mode where it works, switch to high-contrast white in dark mode. The ink bar still carries the brand color, so the selection signal stays brand-aware.
- Specify \`colorTextSecondary\` / \`colorTextTertiary\` / \`colorTextQuaternary\` for both modes. Ant Design's defaults are close to these values, but making them explicit documents the intent, ensures parity with the already-explicit \`colorTextBase\`, and protects against algorithm drift across AntD versions.

**\`web/src/index.css\`**
- Input focus state in dark mode previously only overrode \`background-color\`. The green \`border-color\` and \`box-shadow\` from the light-mode rule were inherited, making the focus ring faint against the dark background. Lift to \`#7ec496\` with a stronger ring opacity so focus stays unmistakable without being garish.

### Test plan

- [x] \`bun run lint\` — eslint + i18n parity (1212 keys consistent)
- [x] \`bun run build\` — tsc + vite
- [x] \`bun run test\` — 144/144

### Notes

This is the first of three planned passes; subsequent PRs will sweep hardcoded color literals across components and add CSS dark-mode overrides for primary buttons / vault card border gradients.