### PR TITLE
style(theme): hardcoded colors → tokens + dark-mode CSS polish

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -25,6 +25,21 @@ export default defineConfig([
         'ts-expect-error': true,
         'ts-nocheck': true,
       }],
+      // Forbid hardcoded color/background literals inside JSX style props.
+      // A literal "#fff" doesn't switch with dark mode and ignores theme
+      // overrides; use AntD tokens (e.g. token.colorTextLightSolid for
+      // white-on-brand, token.colorError for danger, token.colorPrimary
+      // for the brand accent). Third-party brand colors that must stay
+      // constant (e.g. Telegram blue) can opt out with a narrow
+      // `// eslint-disable-next-line no-restricted-syntax` comment.
+      'no-restricted-syntax': ['error', {
+        // Only flag hex and named colors — rgba()/rgb() with explicit
+        // alpha is often intentional (overlays, semi-transparent
+        // backgrounds), and forbidding those produces too many false
+        // positives. Hex and named colors should always be tokens.
+        selector: "JSXAttribute[name.name='style'] ObjectExpression Property[key.name=/^(color|background|backgroundColor|borderColor)$/] > Literal[value=/^(#[0-9a-fA-F]{3,8}|red|blue|green|black|white|grey|gray)$/]",
+        message: 'Hardcoded color in style prop. Use theme tokens (token.colorXxx) so dark/light mode switching works.',
+      }],
     },
   },
   {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -141,6 +141,12 @@ html[data-theme="dark"] .ant-list-item:hover {
   opacity: 1;
 }
 
+/* Dark mode: the same gradient sinks into the dark card bg. Use the
+   lighter shade range so the accent stays visible. */
+html[data-theme="dark"] .bonds-vault-card::before {
+  background: linear-gradient(90deg, #7ec496, #aed4b8);
+}
+
 /* Buttons with distinct character */
 .ant-btn {
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
@@ -161,6 +167,18 @@ html[data-theme="dark"] .ant-list-item:hover {
   transform: translateY(-1px);
   box-shadow: 0 6px 16px rgba(74, 124, 89, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.2) inset !important;
   background: linear-gradient(135deg, #568f66, #427553) !important;
+}
+
+/* Dark mode: lift the gradient one stop so the button doesn't sink into
+   a dark container. Same lighter green the focus ring already adopts. */
+html[data-theme="dark"] .ant-btn-primary {
+  background: linear-gradient(135deg, #5e9b73, #4a7c59) !important;
+  box-shadow: 0 4px 12px rgba(126, 196, 150, 0.25) !important;
+}
+
+html[data-theme="dark"] .ant-btn-primary:not(:disabled):hover {
+  background: linear-gradient(135deg, #7ec496, #5e9b73) !important;
+  box-shadow: 0 6px 16px rgba(126, 196, 150, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.15) inset !important;
 }
 
 /* Beautiful tag design */
@@ -384,15 +402,18 @@ html[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.22);
 }
 
-/* Inputs & Form */
+/* Inputs & Form
+   Solid backgrounds (vs. the previous semi-transparent + backdrop-filter
+   treatment). The frosted-glass look made placeholder text fight the
+   layout's noise/grid texture and read as muddy in both modes; opaque
+   bg keeps inputs crisp. Focus state below restores the brand accent. */
 .ant-input, .ant-input-password, .ant-select-selector {
   border-color: rgba(0,0,0,0.1) !important;
-  background-color: rgba(255,255,255,0.7) !important;
-  backdrop-filter: blur(4px);
+  background-color: #ffffff !important;
 }
 html[data-theme="dark"] .ant-input, html[data-theme="dark"] .ant-input-password, html[data-theme="dark"] .ant-select-selector {
   border-color: rgba(255,255,255,0.1) !important;
-  background-color: rgba(0,0,0,0.2) !important;
+  background-color: #1a1e1b !important;
 }
 
 .ant-input:focus, .ant-input-focused, .ant-select-focused .ant-select-selector {

--- a/web/src/pages/admin/Backups.tsx
+++ b/web/src/pages/admin/Backups.tsx
@@ -113,9 +113,9 @@ export default function AdminBackups() {
       content: (
         <div>
           <p>{t("backups.restore_confirm")}</p>
-          <p style={{ color: "red", fontWeight: "bold" }}>
+          <Typography.Text type="danger" strong style={{ display: "block", marginTop: 8 }}>
             {t("backups.restore_warning")}
-          </p>
+          </Typography.Text>
         </div>
       ),
       okButtonProps: { danger: true },

--- a/web/src/pages/auth/Login.tsx
+++ b/web/src/pages/auth/Login.tsx
@@ -243,7 +243,7 @@ export default function Login() {
           }}>
             <img src={logoImg} alt="Bonds" style={{ width: 32, height: 32, borderRadius: 8 }} />
             <span style={{
-              fontSize: 20, fontWeight: 700, color: "#fff",
+              fontSize: 20, fontWeight: 700, color: token.colorTextLightSolid,
               letterSpacing: "0.12em", textTransform: "uppercase",
             }}>
               Bonds
@@ -251,7 +251,7 @@ export default function Login() {
           </div>
 
           <h1 style={{
-            fontSize: 34, fontWeight: 400, color: "#fff", lineHeight: 1.3, fontFamily: "\x27Playfair Display\x27, serif",
+            fontSize: 34, fontWeight: 400, color: token.colorTextLightSolid, lineHeight: 1.3, fontFamily: "\x27Playfair Display\x27, serif",
             margin: "0 0 16px 0", letterSpacing: "-0.01em",
           }}>
             {t("auth.login.hero_title")}

--- a/web/src/pages/auth/OAuthLink.tsx
+++ b/web/src/pages/auth/OAuthLink.tsx
@@ -279,7 +279,7 @@ export default function OAuthLink() {
           }}>
             <img src={logoImg} alt="Bonds" style={{ width: 32, height: 32, borderRadius: 8 }} />
             <span style={{
-              fontSize: 20, fontWeight: 700, color: "#fff",
+              fontSize: 20, fontWeight: 700, color: token.colorTextLightSolid,
               letterSpacing: "0.12em", textTransform: "uppercase",
             }}>
               Bonds
@@ -287,7 +287,7 @@ export default function OAuthLink() {
           </div>
 
           <h1 style={{
-            fontSize: 34, fontWeight: 400, color: "#fff", lineHeight: 1.3, fontFamily: "\x27Playfair Display\x27, serif",
+            fontSize: 34, fontWeight: 400, color: token.colorTextLightSolid, lineHeight: 1.3, fontFamily: "\x27Playfair Display\x27, serif",
             margin: "0 0 16px 0", letterSpacing: "-0.01em",
           }}>
             {t("oauth.link_title")}

--- a/web/src/pages/auth/Register.tsx
+++ b/web/src/pages/auth/Register.tsx
@@ -270,7 +270,7 @@ export default function Register() {
           }}>
             <img src={logoImg} alt="Bonds" style={{ width: 32, height: 32, borderRadius: 8 }} />
             <span style={{
-              fontSize: 20, fontWeight: 700, color: "#fff",
+              fontSize: 20, fontWeight: 700, color: token.colorTextLightSolid,
               letterSpacing: "0.12em", textTransform: "uppercase",
             }}>
               Bonds
@@ -278,7 +278,7 @@ export default function Register() {
           </div>
 
           <h1 style={{
-            fontSize: 34, fontWeight: 400, color: "#fff", lineHeight: 1.3, fontFamily: "\x27Playfair Display\x27, serif",
+            fontSize: 34, fontWeight: 400, color: token.colorTextLightSolid, lineHeight: 1.3, fontFamily: "\x27Playfair Display\x27, serif",
             margin: "0 0 16px 0", letterSpacing: "-0.01em",
           }}>
             {t("auth.register.hero_title")}

--- a/web/src/pages/contact/ContactDetail.tsx
+++ b/web/src/pages/contact/ContactDetail.tsx
@@ -890,7 +890,7 @@ function AvatarImageLoader({
           style={{ width: "100%", height: "100%", objectFit: "cover" }}
         />
       ) : (
-        <span style={{ fontSize: 30, color: "#fff", fontWeight: 500 }}>
+        <span style={{ fontSize: 30, color: token.colorTextLightSolid, fontWeight: 500 }}>
           {initials}
         </span>
       )}
@@ -925,8 +925,8 @@ function AvatarImageLoader({
             >
               <Button
                 type="text"
-                icon={<CameraOutlined style={{ color: "#fff", fontSize: 20 }} />}
-                style={{ color: "#fff" }}
+                icon={<CameraOutlined style={{ color: token.colorTextLightSolid, fontSize: 20 }} />}
+                style={{ color: token.colorTextLightSolid }}
               />
             </Upload>
             {hasAvatar && (
@@ -936,7 +936,7 @@ function AvatarImageLoader({
               >
                  <Button
                   type="text"
-                  icon={<DeleteOutlined style={{ color: "#fff", fontSize: 16 }} />}
+                  icon={<DeleteOutlined style={{ color: token.colorTextLightSolid, fontSize: 16 }} />}
                   danger
                 />
               </Popconfirm>

--- a/web/src/pages/settings/Personalize.tsx
+++ b/web/src/pages/settings/Personalize.tsx
@@ -123,6 +123,7 @@ function SubItemsPanel({ parentId, sectionKey }: { parentId: number; sectionKey:
   const [expandedModulePageId, setExpandedModulePageId] = useState<number | null>(null);
   const showModules = sectionKey === "templates";
   const queryClient = useQueryClient();
+  const { token } = theme.useToken();
   const { message } = App.useApp();
   const { t } = useTranslation();
   const qk = ["settings", "personalize", sectionKey, "sub-items", parentId];
@@ -282,7 +283,7 @@ function SubItemsPanel({ parentId, sectionKey }: { parentId: number; sectionKey:
                     icon={<AppstoreOutlined />}
                     title={t("settings.personalize.page_modules")}
                     onClick={() => setExpandedModulePageId(expandedModulePageId === (item.id as number) ? null : (item.id as number))}
-                    style={expandedModulePageId === (item.id as number) ? { color: '#1677ff' } : undefined}
+                    style={expandedModulePageId === (item.id as number) ? { color: token.colorPrimary } : undefined}
                   />,
                 ] : []),
                 <Button key="e" type="text" size="small" icon={<EditOutlined />} onClick={() => startEdit(item)} />,
@@ -734,6 +735,7 @@ function SectionCollapseLabel({
   sectionKey: string;
   label: string;
 }) {
+  const { token } = theme.useToken();
   const { data: items = [] } = useQuery({
     queryKey: ["settings", "personalize", sectionKey],
     queryFn: async () => {
@@ -748,8 +750,8 @@ function SectionCollapseLabel({
       <Badge
         count={items.length}
         showZero
-        color="#d9d9d9"
-        style={{ color: "#666", fontSize: 11 }}
+        color={token.colorBorderSecondary}
+        style={{ color: token.colorTextTertiary, fontSize: 11 }}
       />
     </span>
   );

--- a/web/src/pages/settings/Settings.tsx
+++ b/web/src/pages/settings/Settings.tsx
@@ -81,7 +81,7 @@ export default function Settings() {
             {initials ? (
               <span
                 style={{
-                  color: "#fff",
+                  color: token.colorTextLightSolid,
                   fontSize: 20,
                   fontWeight: 600,
                   lineHeight: 1,
@@ -90,7 +90,7 @@ export default function Settings() {
                 {initials}
               </span>
             ) : (
-              <UserOutlined style={{ color: "#fff", fontSize: 24 }} />
+              <UserOutlined style={{ color: token.colorTextLightSolid, fontSize: 24 }} />
             )}
           </div>
           <div style={{ minWidth: 0 }}>

--- a/web/src/pages/settings/Users.tsx
+++ b/web/src/pages/settings/Users.tsx
@@ -139,7 +139,7 @@ export default function Users() {
                 alignItems: "center",
                 justifyContent: "center",
                 flexShrink: 0,
-                color: "#fff",
+                color: token.colorTextLightSolid,
                 fontSize: 13,
                 fontWeight: 600,
               }}

--- a/web/src/pages/vault/VaultFiles.tsx
+++ b/web/src/pages/vault/VaultFiles.tsx
@@ -82,7 +82,7 @@ export default function VaultFiles() {
     if (mimeType.startsWith("image/"))
       return <FileImageOutlined style={{ fontSize: 18, color: token.colorSuccess }} />;
     if (mimeType === "application/pdf")
-      return <FilePdfOutlined style={{ fontSize: 18, color: "#e74c3c" }} />;
+      return <FilePdfOutlined style={{ fontSize: 18, color: token.colorError }} />;
     return <FileOutlined style={{ fontSize: 18, color: token.colorPrimary }} />;
   }
 

--- a/web/src/pages/vault/VaultSettings.tsx
+++ b/web/src/pages/vault/VaultSettings.tsx
@@ -772,7 +772,7 @@ export default function VaultSettings() {
                                         onClick={(e) => { e.stopPropagation(); setEditingCatId(cat.id!); setEditingCatLabel(cat.label ?? ""); }}
                                     />
                                     <Popconfirm title={t("common.delete_confirm")} onConfirm={(e) => { e?.stopPropagation(); deleteCategory.mutate(cat.id!); }}>
-                                        <DeleteOutlined onClick={(e) => e.stopPropagation()} style={{color: 'red'}} />
+                                        <DeleteOutlined onClick={(e) => e.stopPropagation()} style={{ color: token.colorError }} />
                                     </Popconfirm>
                                 </Space>
                             }


### PR DESCRIPTION
A small theme cleanup pass with three concerns. 12 files, +62/-24.

## Screenshots

<!-- screenshot: dark mode primary button + vault card accent visibility -->

<!-- screenshot: input field clarity (was: muddy frosted glass; now: solid bg) -->

## Branch B — TSX color literals → theme tokens

A handful of components had hardcoded color literals in JSX `style` props that don't switch with theme:

- `#fff` on white-on-brand-bg avatars and hero text → `token.colorTextLightSolid` (the AntD-blessed always-light token). Affects: `ContactDetail` avatar overlays, `Settings`/`Users` avatars, `Login`/`Register`/`OAuthLink` hero text.
- Ad-hoc danger reds (`#e74c3c`, `'red'`) → `token.colorError` in `VaultFiles`, `VaultSettings`, `Backups` (the last via `Typography.Text type=\"danger\"` inside a modal callback where `token` isn't reachable from a render closure).
- `#1677ff` (AntD blue) → `token.colorPrimary` in `Personalize`'s active-item indicator. Bonds' brand here is botanical green, not AntD blue.
- `#666` / `#d9d9d9` hint colors → `colorTextTertiary` / `colorBorderSecondary` on `Personalize`'s section-count Badge.

Adds `useToken()` to two `Personalize` subcomponents (`SubItemsPanel`, `SectionCollapseLabel`) that previously didn't have it in scope.

## Branch C — CSS dark-mode polish

Three rules that hadn't been overridden for dark mode:

- **`.ant-btn-primary`** — the brand-green gradient `linear-gradient(135deg, #4a7c59, #3d6a4c)` looks great on a light bg but disappears into dark containers. Add a `html[data-theme=\"dark\"]` override using the lighter botanical greens (`#5e9b73 → #4a7c59` base, `#7ec496 → #5e9b73` hover) — same range the input focus ring already adopted.
- **`.bonds-vault-card::before`** — same problem on the top-edge accent gradient. Lighter shade range in dark mode keeps the accent visible against the dark card bg.
- **`.ant-input` / `.ant-select-selector`** — replace the semi-transparent `rgba(255,255,255,0.7)` + `backdrop-filter` treatment with solid backgrounds (`#ffffff` light, `#1a1e1b` dark). The frosted-glass look read as muddy against the layout's noise/grid texture, and placeholder text fought the pattern. Focus state's brand accent is unchanged.

## ESLint guard against regression

Adds a `no-restricted-syntax` rule to the existing `eslint.config.js` that flags hex and named-color literals in JSX `style` props going forward, with a message pointing at theme tokens. `rgba()` / `rgb()` with explicit alpha is allowed — there are too many legitimate uses for transparent overlays / hover scrims / specific opacity values to forbid them generally. Brand-specific colors that must stay constant (third-party service brand colors like Telegram blue) can opt out with a narrow `// eslint-disable-next-line no-restricted-syntax` comment.

## Test plan

- [x] `bun run lint` — eslint + i18n key check pass
- [x] `bun run build` — tsc + vite
- [x] `bun run test` — 144/144

## Notes

The `Notifications.tsx` channel colors (Telegram `#0088cc`, ntfy `#52c41a`, Gotify `#fa8c16`, etc.) are intentionally left as-is — they're third-party brand colors, not theme colors. The new ESLint rule would not flag them because they're not in the listed paths, but if anyone moves them into a `style` prop in the future the comment above explains the opt-out.