### PR TITLE
feat(addresses): move-in/move-out timeline on contact addresses

### DIFF
--- a/server/internal/dto/address.go
+++ b/server/internal/dto/address.go
@@ -3,44 +3,50 @@ package dto
 import "time"
 
 type CreateAddressRequest struct {
-	Line1         string   `json:"line_1" example:"123 Main Street"`
-	Line2         string   `json:"line_2" example:"Apt 4B"`
-	City          string   `json:"city" example:"San Francisco"`
-	Province      string   `json:"province" example:"California"`
-	PostalCode    string   `json:"postal_code" example:"94102"`
-	Country       string   `json:"country" example:"US"`
-	AddressTypeID *uint    `json:"address_type_id" example:"1"`
-	Latitude      *float64 `json:"latitude" example:"37.7749"`
-	Longitude     *float64 `json:"longitude" example:"-122.4194"`
-	IsPastAddress bool     `json:"is_past_address" example:"false"`
+	Line1         string     `json:"line_1" example:"123 Main Street"`
+	Line2         string     `json:"line_2" example:"Apt 4B"`
+	City          string     `json:"city" example:"San Francisco"`
+	Province      string     `json:"province" example:"California"`
+	PostalCode    string     `json:"postal_code" example:"94102"`
+	Country       string     `json:"country" example:"US"`
+	AddressTypeID *uint      `json:"address_type_id" example:"1"`
+	Latitude      *float64   `json:"latitude" example:"37.7749"`
+	Longitude     *float64   `json:"longitude" example:"-122.4194"`
+	IsPastAddress bool       `json:"is_past_address" example:"false"`
+	DateFrom      *time.Time `json:"date_from" example:"2024-09-01T00:00:00Z"`
+	DateTo        *time.Time `json:"date_to" example:"2025-08-31T00:00:00Z"`
 }
 
 type UpdateAddressRequest struct {
-	Line1         string   `json:"line_1" example:"123 Main Street"`
-	Line2         string   `json:"line_2" example:"Apt 4B"`
-	City          string   `json:"city" example:"San Francisco"`
-	Province      string   `json:"province" example:"California"`
-	PostalCode    string   `json:"postal_code" example:"94102"`
-	Country       string   `json:"country" example:"US"`
-	AddressTypeID *uint    `json:"address_type_id" example:"1"`
-	Latitude      *float64 `json:"latitude" example:"37.7749"`
-	Longitude     *float64 `json:"longitude" example:"-122.4194"`
-	IsPastAddress bool     `json:"is_past_address" example:"false"`
+	Line1         string     `json:"line_1" example:"123 Main Street"`
+	Line2         string     `json:"line_2" example:"Apt 4B"`
+	City          string     `json:"city" example:"San Francisco"`
+	Province      string     `json:"province" example:"California"`
+	PostalCode    string     `json:"postal_code" example:"94102"`
+	Country       string     `json:"country" example:"US"`
+	AddressTypeID *uint      `json:"address_type_id" example:"1"`
+	Latitude      *float64   `json:"latitude" example:"37.7749"`
+	Longitude     *float64   `json:"longitude" example:"-122.4194"`
+	IsPastAddress bool       `json:"is_past_address" example:"false"`
+	DateFrom      *time.Time `json:"date_from" example:"2024-09-01T00:00:00Z"`
+	DateTo        *time.Time `json:"date_to" example:"2025-08-31T00:00:00Z"`
 }
 
 type AddressResponse struct {
-	ID            uint      `json:"id" example:"1"`
-	VaultID       string    `json:"vault_id" example:"550e8400-e29b-41d4-a716-446655440000"`
-	Line1         string    `json:"line_1" example:"123 Main Street"`
-	Line2         string    `json:"line_2" example:"Apt 4B"`
-	City          string    `json:"city" example:"San Francisco"`
-	Province      string    `json:"province" example:"California"`
-	PostalCode    string    `json:"postal_code" example:"94102"`
-	Country       string    `json:"country" example:"US"`
-	AddressTypeID *uint     `json:"address_type_id" example:"1"`
-	Latitude      *float64  `json:"latitude" example:"37.7749"`
-	Longitude     *float64  `json:"longitude" example:"-122.4194"`
-	IsPastAddress bool      `json:"is_past_address" example:"false"`
-	CreatedAt     time.Time `json:"created_at" example:"2026-01-15T10:30:00Z"`
-	UpdatedAt     time.Time `json:"updated_at" example:"2026-01-15T10:30:00Z"`
+	ID            uint       `json:"id" example:"1"`
+	VaultID       string     `json:"vault_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Line1         string     `json:"line_1" example:"123 Main Street"`
+	Line2         string     `json:"line_2" example:"Apt 4B"`
+	City          string     `json:"city" example:"San Francisco"`
+	Province      string     `json:"province" example:"California"`
+	PostalCode    string     `json:"postal_code" example:"94102"`
+	Country       string     `json:"country" example:"US"`
+	AddressTypeID *uint      `json:"address_type_id" example:"1"`
+	Latitude      *float64   `json:"latitude" example:"37.7749"`
+	Longitude     *float64   `json:"longitude" example:"-122.4194"`
+	IsPastAddress bool       `json:"is_past_address" example:"false"`
+	DateFrom      *time.Time `json:"date_from" example:"2024-09-01T00:00:00Z"`
+	DateTo        *time.Time `json:"date_to" example:"2025-08-31T00:00:00Z"`
+	CreatedAt     time.Time  `json:"created_at" example:"2026-01-15T10:30:00Z"`
+	UpdatedAt     time.Time  `json:"updated_at" example:"2026-01-15T10:30:00Z"`
 }

--- a/server/internal/models/address.go
+++ b/server/internal/models/address.go
@@ -35,12 +35,19 @@ type Address struct {
 }
 
 type ContactAddress struct {
-	ID            uint      `json:"id" gorm:"primaryKey;autoIncrement"`
-	ContactID     string    `json:"contact_id" gorm:"type:text;not null;index"`
-	AddressID     uint      `json:"address_id" gorm:"not null;index"`
-	IsPastAddress bool      `json:"is_past_address" gorm:"default:false"`
-	CreatedAt     time.Time `json:"created_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
+	ID            uint       `json:"id" gorm:"primaryKey;autoIncrement"`
+	ContactID     string     `json:"contact_id" gorm:"type:text;not null;index"`
+	AddressID     uint       `json:"address_id" gorm:"not null;index"`
+	IsPastAddress bool       `json:"is_past_address" gorm:"default:false"`
+	// DateFrom: when the contact moved in. Nullable — old rows have no
+	// timeline data; users can fill in over time.
+	DateFrom *time.Time `json:"date_from"`
+	// DateTo: when they moved out. Setting this implies IsPastAddress=true
+	// (the service enforces that). Nullable means "still living there"
+	// when IsPastAddress=false, "unknown end date" when IsPastAddress=true.
+	DateTo    *time.Time `json:"date_to"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
 }
 
 func (ContactAddress) TableName() string {

--- a/server/internal/services/address.go
+++ b/server/internal/services/address.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"time"
 
 	"github.com/naiba/bonds/internal/dto"
 	"github.com/naiba/bonds/internal/models"
@@ -41,10 +42,10 @@ func (s *AddressService) List(contactID, vaultID string) ([]dto.AddressResponse,
 	}
 
 	addressIDs := make([]uint, len(pivots))
-	pastMap := make(map[uint]bool)
+	pivotByAddr := make(map[uint]models.ContactAddress)
 	for i, p := range pivots {
 		addressIDs[i] = p.AddressID
-		pastMap[p.AddressID] = p.IsPastAddress
+		pivotByAddr[p.AddressID] = p
 	}
 
 	var addresses []models.Address
@@ -54,7 +55,8 @@ func (s *AddressService) List(contactID, vaultID string) ([]dto.AddressResponse,
 
 	result := make([]dto.AddressResponse, len(addresses))
 	for i, a := range addresses {
-		result[i] = toAddressResponse(&a, pastMap[a.ID])
+		p := pivotByAddr[a.ID]
+		result[i] = toAddressResponse(&a, p.IsPastAddress, p.DateFrom, p.DateTo)
 	}
 	return result, nil
 }
@@ -76,6 +78,10 @@ func (s *AddressService) Create(contactID, vaultID string, req dto.CreateAddress
 		Longitude:     req.Longitude,
 	}
 
+	// A non-null DateTo implies the contact has moved out — auto-flip
+	// IsPastAddress to true so the two fields can't disagree silently.
+	isPast := req.IsPastAddress || req.DateTo != nil
+
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(&address).Error; err != nil {
 			return err
@@ -83,9 +89,19 @@ func (s *AddressService) Create(contactID, vaultID string, req dto.CreateAddress
 		pivot := models.ContactAddress{
 			ContactID:     contactID,
 			AddressID:     address.ID,
-			IsPastAddress: req.IsPastAddress,
+			IsPastAddress: isPast,
+			DateFrom:      req.DateFrom,
+			DateTo:        req.DateTo,
 		}
-		return tx.Create(&pivot).Error
+		// Honor the GORM zero-value-bool trap for the false-explicit case
+		// (per AGENTS.md). Create skips false; a separate Update locks it in.
+		if err := tx.Create(&pivot).Error; err != nil {
+			return err
+		}
+		if !isPast {
+			return tx.Model(&pivot).Update("is_past_address", false).Error
+		}
+		return nil
 	})
 	if err != nil {
 		return nil, err
@@ -98,7 +114,7 @@ func (s *AddressService) Create(contactID, vaultID string, req dto.CreateAddress
 		s.feedRecorder.Record(contactID, "", ActionAddressAdded, "Added an address", &address.ID, &entityType)
 	}
 
-	resp := toAddressResponse(&address, req.IsPastAddress)
+	resp := toAddressResponse(&address, isPast, req.DateFrom, req.DateTo)
 	return &resp, nil
 }
 
@@ -129,18 +145,21 @@ func (s *AddressService) Update(id uint, contactID, vaultID string, req dto.Upda
 	address.Latitude = req.Latitude
 	address.Longitude = req.Longitude
 
+	isPast := req.IsPastAddress || req.DateTo != nil
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Save(&address).Error; err != nil {
 			return err
 		}
-		pivot.IsPastAddress = req.IsPastAddress
+		pivot.IsPastAddress = isPast
+		pivot.DateFrom = req.DateFrom
+		pivot.DateTo = req.DateTo
 		return tx.Save(&pivot).Error
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	resp := toAddressResponse(&address, req.IsPastAddress)
+	resp := toAddressResponse(&address, isPast, req.DateFrom, req.DateTo)
 	return &resp, nil
 }
 
@@ -189,7 +208,7 @@ func (s *AddressService) tryGeocode(address *models.Address) {
 	s.db.Model(address).Select("latitude", "longitude").Updates(address)
 }
 
-func toAddressResponse(a *models.Address, isPastAddress bool) dto.AddressResponse {
+func toAddressResponse(a *models.Address, isPastAddress bool, dateFrom, dateTo *time.Time) dto.AddressResponse {
 	return dto.AddressResponse{
 		ID:            a.ID,
 		VaultID:       a.VaultID,
@@ -203,6 +222,8 @@ func toAddressResponse(a *models.Address, isPastAddress bool) dto.AddressRespons
 		Latitude:      a.Latitude,
 		Longitude:     a.Longitude,
 		IsPastAddress: isPastAddress,
+		DateFrom:      dateFrom,
+		DateTo:        dateTo,
 		CreatedAt:     a.CreatedAt,
 		UpdatedAt:     a.UpdatedAt,
 	}

--- a/server/internal/services/address_test.go
+++ b/server/internal/services/address_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"testing"
+	"time"
 
 	"github.com/naiba/bonds/internal/dto"
 	"github.com/naiba/bonds/internal/testutil"
@@ -131,6 +132,78 @@ func TestDeleteAddress(t *testing.T) {
 	}
 	if len(addresses) != 0 {
 		t.Errorf("Expected 0 addresses after delete, got %d", len(addresses))
+	}
+}
+
+func TestAddressTimeline(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+
+	from := time.Date(2024, 9, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2025, 8, 31, 0, 0, 0, 0, time.UTC)
+
+	// Create with date_to set; service should auto-flip is_past_address.
+	addr, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1:    "10 rue François Mouthon",
+		City:     "Paris",
+		Country:  "FR",
+		DateFrom: &from,
+		DateTo:   &to,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if !addr.IsPastAddress {
+		t.Errorf("DateTo set should auto-flip IsPastAddress=true, got false")
+	}
+	if addr.DateFrom == nil || !addr.DateFrom.Equal(from) {
+		t.Errorf("DateFrom not round-tripped: got %v, want %v", addr.DateFrom, from)
+	}
+	if addr.DateTo == nil || !addr.DateTo.Equal(to) {
+		t.Errorf("DateTo not round-tripped: got %v, want %v", addr.DateTo, to)
+	}
+
+	// List should return the same dates.
+	all, err := svc.List(contactID, vaultID)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 address, got %d", len(all))
+	}
+	if all[0].DateFrom == nil || !all[0].DateFrom.Equal(from) {
+		t.Errorf("List lost DateFrom")
+	}
+
+	// Current address (no DateTo): IsPastAddress stays false.
+	current, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1:    "Malet Street",
+		City:     "London",
+		Country:  "GB",
+		DateFrom: &to, // moved here when she left Paris
+	})
+	if err != nil {
+		t.Fatalf("Create current failed: %v", err)
+	}
+	if current.IsPastAddress {
+		t.Errorf("DateTo nil should leave IsPastAddress=false (default), got true")
+	}
+	if current.DateTo != nil {
+		t.Errorf("Expected DateTo nil for current address, got %v", current.DateTo)
+	}
+
+	// Update: setting DateTo should also flip IsPastAddress on existing rows.
+	end := time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)
+	updated, err := svc.Update(current.ID, contactID, vaultID, dto.UpdateAddressRequest{
+		Line1:   "Malet Street",
+		City:    "London",
+		Country: "GB",
+		DateTo:  &end,
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if !updated.IsPastAddress {
+		t.Errorf("Setting DateTo on update should flip IsPastAddress=true")
 	}
 }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -706,7 +706,15 @@
       "postal_code": "Postal Code",
       "country": "Country",
       "is_primary": "Primary",
-      "view_map": "View on Google Maps"
+      "view_map": "View on Google Maps",
+      "date_from": "Moved in",
+      "date_from_tooltip": "When the contact started living here. Leave blank if unknown.",
+      "date_to": "Moved out",
+      "date_to_tooltip": "When the contact left. Setting this marks the address as past.",
+      "is_past_address": "Past address",
+      "is_past_address_tooltip": "Mark this address as a former residence.",
+      "past_tag": "Past",
+      "present": "Present"
     },
     "contact_info": {
       "title": "Contact Information",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -706,7 +706,15 @@
       "postal_code": "邮编",
       "country": "国家",
       "is_primary": "主要地址",
-      "view_map": "在谷歌地图查看"
+      "view_map": "在谷歌地图查看",
+      "date_from": "入住时间",
+      "date_from_tooltip": "联系人开始居住的日期。如未知请留空。",
+      "date_to": "搬出时间",
+      "date_to_tooltip": "联系人离开的日期。填写后将标记为过往地址。",
+      "is_past_address": "过往地址",
+      "is_past_address_tooltip": "将此地址标记为旧居。",
+      "past_tag": "过往",
+      "present": "至今"
     },
     "contact_info": {
       "title": "联系方式",

--- a/web/src/pages/contact/modules/AddressesModule.tsx
+++ b/web/src/pages/contact/modules/AddressesModule.tsx
@@ -7,6 +7,7 @@ import {
   Form,
   Input,
   Switch,
+  DatePicker,
   Popconfirm,
   App,
   Tag,
@@ -20,9 +21,22 @@ import {
   EnvironmentOutlined,
 } from "@ant-design/icons";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import dayjs, { type Dayjs } from "dayjs";
 import { api } from "@/api";
 import type { Address, APIError } from "@/api";
 import { useTranslation } from "react-i18next";
+
+interface AddressFormValues {
+  line_1: string;
+  line_2?: string;
+  city: string;
+  province?: string;
+  postal_code?: string;
+  country: string;
+  is_past_address?: boolean;
+  date_from?: Dayjs | null;
+  date_to?: Dayjs | null;
+}
 
 export default function AddressesModule({
   vaultId,
@@ -33,7 +47,7 @@ export default function AddressesModule({
 }) {
   const [open, setOpen] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
-  const [form] = Form.useForm();
+  const [form] = Form.useForm<AddressFormValues>();
   const queryClient = useQueryClient();
   const { message } = App.useApp();
   const { t } = useTranslation();
@@ -49,19 +63,24 @@ export default function AddressesModule({
   });
 
   const saveMutation = useMutation({
-    mutationFn: (values: {
-      line_1: string;
-      line_2?: string;
-      city: string;
-      province?: string;
-      postal_code?: string;
-      country: string;
-      is_past_address?: boolean;
-    }) => {
+    mutationFn: (values: AddressFormValues) => {
+      // Convert Dayjs picker values into ISO strings the backend expects.
+      // null/undefined gets passed through so the backend can clear them.
+      const payload = {
+        line_1: values.line_1,
+        line_2: values.line_2,
+        city: values.city,
+        province: values.province,
+        postal_code: values.postal_code,
+        country: values.country,
+        is_past_address: values.is_past_address ?? false,
+        date_from: values.date_from ? values.date_from.toISOString() : undefined,
+        date_to: values.date_to ? values.date_to.toISOString() : undefined,
+      };
       if (editingId) {
-        return api.addresses.contactsAddressesUpdate(String(vaultId), String(contactId), editingId, values);
+        return api.addresses.contactsAddressesUpdate(String(vaultId), String(contactId), editingId, payload);
       }
-      return api.addresses.contactsAddressesCreate(String(vaultId), String(contactId), values);
+      return api.addresses.contactsAddressesCreate(String(vaultId), String(contactId), payload);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: qk });
@@ -82,7 +101,18 @@ export default function AddressesModule({
 
   function openEdit(a: Address) {
     setEditingId(a.id ?? null);
-    form.setFieldsValue(a);
+    // Address fields in the API are ISO strings; DatePicker expects Dayjs.
+    form.setFieldsValue({
+      line_1: a.line_1 ?? "",
+      line_2: a.line_2 ?? "",
+      city: a.city ?? "",
+      province: a.province ?? "",
+      postal_code: a.postal_code ?? "",
+      country: a.country ?? "",
+      is_past_address: a.is_past_address ?? false,
+      date_from: a.date_from ? dayjs(a.date_from) : null,
+      date_to: a.date_to ? dayjs(a.date_to) : null,
+    });
     setOpen(true);
   }
 
@@ -96,6 +126,16 @@ export default function AddressesModule({
     return [a.line_1, a.line_2, a.city, a.province, a.postal_code, a.country]
       .filter(Boolean)
       .join(", ");
+  }
+
+  function formatRange(a: Address): string | null {
+    const fmt = (d?: string) => (d ? dayjs(d).format("MMM YYYY") : null);
+    const from = fmt(a.date_from);
+    const to = fmt(a.date_to);
+    if (!from && !to) return null;
+    if (from && to) return `${from} → ${to}`;
+    if (from && !to) return `${from} → ${t("modules.addresses.present")}`;
+    return `→ ${to}`;
   }
 
   function mapsUrl(a: Address) {
@@ -124,53 +164,62 @@ export default function AddressesModule({
         dataSource={addresses}
         locale={{ emptyText: <Empty description={t("modules.addresses.no_addresses")} /> }}
         split={false}
-        renderItem={(a: Address) => (
+        renderItem={(a: Address) => {
+          const range = formatRange(a);
+          return (
             <List.Item
-            style={{
-              borderRadius: token.borderRadius,
-              padding: '10px 12px',
-              marginBottom: 4,
-              transition: 'background 0.2s',
-            }}
-            onMouseEnter={(e) => { e.currentTarget.style.background = token.colorFillQuaternary; }}
-            onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
-            actions={[
-              <Button key="map" type="text" size="small" icon={<EnvironmentOutlined />} href={mapsUrl(a)} target="_blank" aria-label={t("modules.addresses.view_map")} />,
-              <Button key="e" type="text" size="small" icon={<EditOutlined />} onClick={() => openEdit(a)} />,
-              <Popconfirm key="d" title={t("modules.addresses.delete_confirm")} onConfirm={() => deleteMutation.mutate(a.id!)}>
-                <Button type="text" size="small" danger icon={<DeleteOutlined />} />
-              </Popconfirm>,
-            ]}
-          >
-            <List.Item.Meta
-              avatar={
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (a as any).latitude && (a as any).longitude ? (
-                  <img 
-                    src={mapImageUrl(a)} 
-                    alt="Map" 
-                    style={{ 
-                      width: 100, 
-                      height: 75, 
-                      objectFit: 'cover', 
-                      borderRadius: token.borderRadiusSM,
-                      border: `1px solid ${token.colorBorderSecondary}`
-                    }} 
-                    onError={(e) => {
-                      e.currentTarget.style.display = 'none';
-                    }}
-                  />
-                ) : null
-              }
-              title={
-                <span style={{ fontWeight: 500 }}>
-                  {a.address_type_id ? `#${a.address_type_id}` : ''} {a.is_past_address && <Tag color="blue">{t("common.primary")}</Tag>}
-                </span>
-              }
-              description={<span style={{ color: token.colorTextSecondary }}>{formatAddress(a)}</span>}
-            />
-          </List.Item>
-        )}
+              style={{
+                borderRadius: token.borderRadius,
+                padding: '10px 12px',
+                marginBottom: 4,
+                transition: 'background 0.2s',
+                opacity: a.is_past_address ? 0.7 : 1,
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = token.colorFillQuaternary; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+              actions={[
+                <Button key="map" type="text" size="small" icon={<EnvironmentOutlined />} href={mapsUrl(a)} target="_blank" aria-label={t("modules.addresses.view_map")} />,
+                <Button key="e" type="text" size="small" icon={<EditOutlined />} onClick={() => openEdit(a)} />,
+                <Popconfirm key="d" title={t("modules.addresses.delete_confirm")} onConfirm={() => deleteMutation.mutate(a.id!)}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} />
+                </Popconfirm>,
+              ]}
+            >
+              <List.Item.Meta
+                avatar={
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  (a as any).latitude && (a as any).longitude ? (
+                    <img
+                      src={mapImageUrl(a)}
+                      alt="Map"
+                      style={{
+                        width: 100,
+                        height: 75,
+                        objectFit: 'cover',
+                        borderRadius: token.borderRadiusSM,
+                        border: `1px solid ${token.colorBorderSecondary}`,
+                      }}
+                      onError={(e) => {
+                        e.currentTarget.style.display = 'none';
+                      }}
+                    />
+                  ) : null
+                }
+                title={
+                  <span style={{ fontWeight: 500, display: 'inline-flex', gap: 8, alignItems: 'center' }}>
+                    {formatAddress(a)}
+                    {a.is_past_address && <Tag>{t("modules.addresses.past_tag")}</Tag>}
+                  </span>
+                }
+                description={
+                  range ? (
+                    <span style={{ color: token.colorTextTertiary, fontSize: 12 }}>{range}</span>
+                  ) : null
+                }
+              />
+            </List.Item>
+          );
+        }}
       />
 
       <Modal
@@ -199,7 +248,26 @@ export default function AddressesModule({
           <Form.Item name="country" label={t("modules.addresses.country")} rules={[{ required: true }]}>
             <Input />
           </Form.Item>
-          <Form.Item name="is_past_address" label={t("modules.addresses.is_primary")} valuePropName="checked">
+          <Form.Item
+            name="date_from"
+            label={t("modules.addresses.date_from")}
+            tooltip={t("modules.addresses.date_from_tooltip")}
+          >
+            <DatePicker style={{ width: "100%" }} format="YYYY-MM-DD" allowClear />
+          </Form.Item>
+          <Form.Item
+            name="date_to"
+            label={t("modules.addresses.date_to")}
+            tooltip={t("modules.addresses.date_to_tooltip")}
+          >
+            <DatePicker style={{ width: "100%" }} format="YYYY-MM-DD" allowClear />
+          </Form.Item>
+          <Form.Item
+            name="is_past_address"
+            label={t("modules.addresses.is_past_address")}
+            valuePropName="checked"
+            tooltip={t("modules.addresses.is_past_address_tooltip")}
+          >
             <Switch />
           </Form.Item>
         </Form>

--- a/web/src/pages/contact/modules/AddressesModule.tsx
+++ b/web/src/pages/contact/modules/AddressesModule.tsx
@@ -25,6 +25,7 @@ import dayjs, { type Dayjs } from "dayjs";
 import { api } from "@/api";
 import type { Address, APIError } from "@/api";
 import { useTranslation } from "react-i18next";
+import { formatMonthYear, useDateFormat } from "@/utils/dateFormat";
 
 interface AddressFormValues {
   line_1: string;
@@ -51,6 +52,7 @@ export default function AddressesModule({
   const queryClient = useQueryClient();
   const { message } = App.useApp();
   const { t } = useTranslation();
+  const dateFormats = useDateFormat();
   const { token } = theme.useToken();
   const qk = ["vaults", vaultId, "contacts", contactId, "addresses"];
 
@@ -129,7 +131,7 @@ export default function AddressesModule({
   }
 
   function formatRange(a: Address): string | null {
-    const fmt = (d?: string) => (d ? dayjs(d).format("MMM YYYY") : null);
+    const fmt = (d?: string) => (d ? formatMonthYear(d, dateFormats) : null);
     const from = fmt(a.date_from);
     const to = fmt(a.date_to);
     if (!from && !to) return null;
@@ -187,8 +189,7 @@ export default function AddressesModule({
             >
               <List.Item.Meta
                 avatar={
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  (a as any).latitude && (a as any).longitude ? (
+                  a.latitude && a.longitude ? (
                     <img
                       src={mapImageUrl(a)}
                       alt="Map"

--- a/web/src/test/AddressesModule.test.tsx
+++ b/web/src/test/AddressesModule.test.tsx
@@ -1,0 +1,60 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { App as AntApp, ConfigProvider } from "antd";
+import { MemoryRouter } from "react-router-dom";
+import AddressesModule from "@/pages/contact/modules/AddressesModule";
+import type { Address } from "@/api";
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+const mockAddresses: Address[] = [
+  {
+    id: 1,
+    line_1: "123 Main St",
+    line_2: "",
+    city: "Paris",
+    province: "",
+    postal_code: "75001",
+    country: "France",
+    is_past_address: true,
+    date_from: "2025-03-01T00:00:00Z",
+    date_to: "2025-04-01T00:00:00Z",
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  },
+];
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: { queryKey: unknown[] }) => {
+    const key = JSON.stringify(opts.queryKey);
+    if (key.includes("preferences")) return { data: { date_format: "YYYY-MM-DD" } };
+    return { data: mockAddresses, isLoading: false };
+  },
+  useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+function renderModule() {
+  return render(
+    <ConfigProvider>
+      <AntApp>
+        <MemoryRouter>
+          <AddressesModule vaultId="v1" contactId="c1" />
+        </MemoryRouter>
+      </AntApp>
+    </ConfigProvider>,
+  );
+}
+
+describe("AddressesModule", () => {
+  it("formats address timeline dates with the user date preference", () => {
+    renderModule();
+    expect(screen.getByText("2025-03 → 2025-04")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds optional `date_from` / `date_to` fields to `ContactAddress` so users can record **when** a contact lived at each address — not just a binary "is_past_address" flag. This makes the address card useful as a residence timeline (e.g. "Paris, Sept 2024 → Aug 2025 → London, Sept 2025 → present").

The service auto-flips `is_past_address = true` whenever `date_to` is set, so the two fields can't disagree silently.

## Changes

**Backend**
- `models.ContactAddress`: nullable `DateFrom *time.Time`, `DateTo *time.Time`
- `dto.CreateAddressRequest` / `UpdateAddressRequest` / `AddressResponse`: pass-through fields
- `AddressService.Create` / `Update`: auto-flip `IsPastAddress` when `DateTo != nil`; honors the GORM zero-value-bool trap for the explicit-false case
- `toAddressResponse` enriched with timeline fields from the pivot
- `TestAddressTimeline`: round-trip + auto-flip on create and update

**Frontend** (`AddressesModule.tsx`)
- Two `DatePicker`s in the modal (`Moved in` / `Moved out`) with ISO ↔ Dayjs conversion
- New `Past` tag (was a mislabeled "primary" tag); dims past addresses to 0.7 opacity
- Date range rendered below each address: `Sep 2024 → Aug 2025` or `Sep 2024 → Present`

## Migration

GORM `AutoMigrate` adds the two nullable columns. No backfill needed — existing rows simply have no timeline data and users can fill it in over time.

## Test plan

- [ ] Add an address with both dates set → "Past" tag appears, range shown
- [ ] Add an address with only `date_from` → range shows `Sep 2024 → Present`, no "Past" tag
- [ ] Edit an existing address and set `date_to` → row auto-flips to past
- [ ] Existing addresses without dates render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)