### PR TITLE
fix(personalize): re-sequence ordered lists so Up/Down actually moves rows

### DIFF
--- a/server/internal/services/personalize_extra.go
+++ b/server/internal/services/personalize_extra.go
@@ -3,25 +3,72 @@ package services
 import (
 	"fmt"
 	"time"
+
+	"gorm.io/gorm"
 )
 
-// UpdatePosition updates the position of an entity in a personalize table
+// UpdatePosition moves entity `id` to index `position` in the account's
+// ordered list for the given entity type. The whole list is re-sequenced
+// (0..N-1) inside a single transaction so positions stay contiguous and
+// unique — the previous implementation only set the moved row's column,
+// which produced ties and left the rendered order unchanged when the
+// (position ASC, id ASC) tiebreaker kept the original order.
 func (s *PersonalizeService) UpdatePosition(accountID, entity string, id uint, position int) error {
 	cfg, ok := entityConfigs[entity]
 	if !ok {
 		return ErrUnknownEntityType
 	}
 
-	now := time.Now()
-	result := s.db.Exec(
-		fmt.Sprintf("UPDATE %s SET position = ?, updated_at = ? WHERE id = ? AND account_id = ?", cfg.table),
-		position, now, id, accountID,
-	)
-	if result.Error != nil {
-		return result.Error
+	type orderedRow struct {
+		ID       uint
+		Position int
 	}
-	if result.RowsAffected == 0 {
-		return ErrPersonalizeEntityNotFound
-	}
-	return nil
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		var rows []orderedRow
+		if err := tx.Raw(
+			fmt.Sprintf("SELECT id, position FROM %s WHERE account_id = ? ORDER BY position ASC, id ASC", cfg.table),
+			accountID,
+		).Scan(&rows).Error; err != nil {
+			return err
+		}
+
+		oldIdx := -1
+		for i, r := range rows {
+			if r.ID == id {
+				oldIdx = i
+				break
+			}
+		}
+		if oldIdx == -1 {
+			return ErrPersonalizeEntityNotFound
+		}
+
+		newIdx := position
+		if newIdx < 0 {
+			newIdx = 0
+		}
+		if newIdx >= len(rows) {
+			newIdx = len(rows) - 1
+		}
+		if oldIdx == newIdx {
+			return nil
+		}
+
+		moved := rows[oldIdx]
+		rows = append(rows[:oldIdx], rows[oldIdx+1:]...)
+		rows = append(rows[:newIdx], append([]orderedRow{moved}, rows[newIdx:]...)...)
+
+		now := time.Now()
+		stmt := fmt.Sprintf("UPDATE %s SET position = ?, updated_at = ? WHERE id = ? AND account_id = ?", cfg.table)
+		for i, r := range rows {
+			if r.Position == i {
+				continue
+			}
+			if err := tx.Exec(stmt, i, now, r.ID, accountID).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
## Summary

The Up/Down arrow buttons on every Personalize entity (task statuses, genders, pronouns, religions, …) fail to move the row when the target position is already occupied by another row.

\`PersonalizeService.UpdatePosition\` was a single-row \`UPDATE\` that left the other rows alone:

\`\`\`go
UPDATE task_statuses SET position = ?, updated_at = ? WHERE id = ? AND account_id = ?
\`\`\`

After this runs, two rows can share the same \`position\`. The list endpoint orders by \`position ASC, id ASC\`, so the older row (smaller id) silently keeps its slot and the moved row appears not to have moved.

## Reproducer

1. Open Settings → Personalize → Task statuses (or any entity with the position controls).
2. Add a new status. It's stored at the largest existing position (or whatever \`createTaskStatus\` assigns — already-tied data is common in fresh installs).
3. Press Up. The row stays put.

## Fix

Re-sequence the whole account's list in one transaction:

1. Read every row for this account ordered by \`(position ASC, id ASC)\`.
2. Splice the moved row to the requested index.
3. Rewrite each row's \`position\` so the sequence is \`0..N-1\` contiguous. Skip rows whose position doesn't change (small write savings, mostly clarity).

Robust to pre-existing ties from older data. Out-of-range \`position\` values are clamped to \`[0, N-1]\`.

## Test plan

- [ ] Add a new task status, press Up — actually moves and stays moved across refresh.
- [ ] Verify the same on Genders / Pronouns / Religions / any other personalize entity.
- [ ] Inspect the DB after a few Up/Down operations — positions are dense \`0..N-1\` with no ties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)