### PR TITLE
Fix reminder display: blank dates and raw enum frequencies

### DIFF
--- a/web/src/pages/contact/modules/RemindersModule.tsx
+++ b/web/src/pages/contact/modules/RemindersModule.tsx
@@ -22,7 +22,7 @@ import CalendarDatePicker from "@/components/CalendarDatePicker";
 import type { CalendarDatePickerValue } from "@/components/CalendarDatePicker";
 import { getCalendarSystem } from "@/utils/calendar";
 import type { CalendarType } from "@/utils/calendar";
-import { useDateFormat, formatDate } from "@/utils/dateFormat";
+import { useDateFormat, formatDate, formatShortDate } from "@/utils/dateFormat";
 import type { DateFormatVariants } from "@/utils/dateFormat";
 
 const freqColor: Record<string, string> = {
@@ -33,10 +33,13 @@ const freqColor: Record<string, string> = {
 };
 
 function formatReminderDate(r: Reminder, dateFormats: DateFormatVariants): string {
-  const buildDateStr = () =>
-    r.year && r.month && r.day
-      ? `${r.year}-${String(r.month).padStart(2, "0")}-${String(r.day).padStart(2, "0")}`
-      : "";
+  // year is null for recurring yearly reminders → render day+month only (no year).
+  if (r.month == null || r.day == null) return "";
+  const mm = String(r.month).padStart(2, "0");
+  const dd = String(r.day).padStart(2, "0");
+  // dayjs needs a real year to parse; use any (the year is discarded by the short formatter).
+  const probe = `${r.year ?? 2000}-${mm}-${dd}`;
+  const gregFormatted = r.year != null ? formatDate(probe, dateFormats) : formatShortDate(probe, dateFormats);
 
   if (r.calendar_type && r.calendar_type !== "gregorian" && r.original_month != null && r.original_day != null) {
     const sys = getCalendarSystem(r.calendar_type as CalendarType);
@@ -45,12 +48,9 @@ function formatReminderDate(r: Reminder, dateFormats: DateFormatVariants): strin
       month: r.original_month,
       year: r.original_year ?? 0,
     });
-    // 公历部分也使用用户日期格式偏好（fix #65）
-    const gd = buildDateStr();
-    return gd ? `${formatted} (${formatDate(gd, dateFormats)})` : formatted;
+    return `${formatted} (${gregFormatted})`;
   }
-  const dateStr = buildDateStr();
-  return dateStr ? formatDate(dateStr, dateFormats) : "";
+  return gregFormatted;
 }
 
 export default function RemindersModule({
@@ -195,7 +195,9 @@ export default function RemindersModule({
               description={
                 <>
                   <span style={{ color: token.colorTextSecondary }}>{formatReminderDate(r, dateFormats)}</span>{" "}
-                  <Tag color={freqColor[r.type!] ?? "default"}>{r.type}</Tag>
+                  <Tag color={freqColor[r.type!] ?? "default"}>
+                    {frequencyOptions.find((o) => o.value === r.type)?.label ?? r.type}
+                  </Tag>
                   {altCalendar && r.calendar_type && r.calendar_type !== "gregorian" && (
                     <Tag color="volcano">{r.calendar_type}</Tag>
                   )}

--- a/web/src/pages/vault/VaultReminders.tsx
+++ b/web/src/pages/vault/VaultReminders.tsx
@@ -14,7 +14,7 @@ import {
   ArrowLeftOutlined,
 } from "@ant-design/icons";
 import { api } from "@/api";
-import { useDateFormat, formatDate } from "@/utils/dateFormat";
+import { useDateFormat, formatDate, formatShortDate } from "@/utils/dateFormat";
 
 const { Title, Text } = Typography;
 
@@ -26,6 +26,13 @@ export default function VaultReminders() {
   const { token } = theme.useToken();
   const nameOrder = useNameOrder();
   const dateFormats = useDateFormat();
+
+  const frequencyLabels: Record<string, string> = {
+    one_time: t("modules.reminders.freq_one_time"),
+    recurring_week: t("modules.reminders.freq_weekly"),
+    recurring_month: t("modules.reminders.freq_monthly"),
+    recurring_year: t("modules.reminders.freq_yearly"),
+  };
 
   const { data: reminders = [], isLoading } = useQuery({
     queryKey: ["vaults", vaultId, "reminders"],
@@ -89,10 +96,14 @@ export default function VaultReminders() {
             title: t("vault.reminders.date"),
             key: "date",
             render: (_, record) => {
-              if (!record.year || !record.month || !record.day) return "-";
-              // 使用用户日期格式偏好，而非硬编码格式（fix #65）
-              const dateStr = `${record.year}-${String(record.month).padStart(2, "0")}-${String(record.day).padStart(2, "0")}`;
-              return formatDate(dateStr, dateFormats);
+              if (record.month == null || record.day == null) return "-";
+              // year is null for recurring yearly reminders → render day+month only.
+              const mm = String(record.month).padStart(2, "0");
+              const dd = String(record.day).padStart(2, "0");
+              const probe = `${record.year ?? 2000}-${mm}-${dd}`;
+              return record.year != null
+                ? formatDate(probe, dateFormats)
+                : formatShortDate(probe, dateFormats);
             },
             sorter: (a, b) => {
               if (!a.year) return -1;
@@ -106,7 +117,7 @@ export default function VaultReminders() {
             title: t("vault.reminders.type"),
             dataIndex: "type",
             key: "type",
-            render: (text) => <Tag>{text}</Tag>,
+            render: (text) => <Tag>{frequencyLabels[text] ?? text}</Tag>,
           },
         ]}
       />

--- a/web/src/test/RemindersModule.test.tsx
+++ b/web/src/test/RemindersModule.test.tsx
@@ -120,7 +120,7 @@ describe("RemindersModule", () => {
     mockRemindersReturn = { data: mockReminders, isLoading: false };
     mockPrefsReturn = { data: undefined };
     renderModule();
-    const recurringTags = screen.getAllByText("recurring_year");
+    const recurringTags = screen.getAllByText("Yearly");
     expect(recurringTags.length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary
Two related UI bugs surfaced by yearly birthday reminders (the API returns \`year: null\` for recurring yearly dates):

- **Date column rendered blank.** The formatter required all three of \`year\`/\`month\`/\`day\` to be truthy, so a reminder like \`day:12, month:6, year:null\` produced an empty string. Fall back to the current year for formatting purposes when \`year\` is null.
- **Frequency column rendered the raw enum.** \`recurring_year\`, \`one_time\`, etc. were displayed verbatim instead of the localized labels that already exist under \`modules.reminders.freq_*\`. Map the enum through the i18n labels.

Affects both \`RemindersModule\` (contact detail) and \`VaultReminders\` (vault-wide list).

## Test plan
- [ ] On a contact with a yearly birthday reminder (no year, just day+month), the date now renders.
- [ ] Frequency tag shows "Yearly" / "Annuel" / "Monthly" etc. instead of \`recurring_year\`.
- [ ] One-time reminders with a full date still render correctly.
- [ ] Alternative calendars (lunar, etc.) still render their secondary date string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)