### PR TITLE
docs: add Discord community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Release](https://github.com/naiba/bonds/actions/workflows/release.yml/badge.svg)](https://github.com/naiba/bonds/actions/workflows/release.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/naiba/bonds)](https://github.com/naiba/bonds/releases)
 
-📖 [Documentation](https://naiba.github.io/bonds/) | [中文文档](README_zh.md)
+📖 [Documentation](https://naiba.github.io/bonds/) | [中文文档](README_zh.md) | 💬 [Discord](https://discord.gg/faaEJyt4h)
 
 <a href="https://www.producthunt.com/products/bonds?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-bonds" target="_blank" rel="noopener noreferrer"><img alt="Bonds - Remember everything about the people who matter. | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1091729&amp;theme=light&amp;t=1772852214754"></a>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,7 +4,7 @@
 [![Release](https://github.com/naiba/bonds/actions/workflows/release.yml/badge.svg)](https://github.com/naiba/bonds/actions/workflows/release.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/naiba/bonds)](https://github.com/naiba/bonds/releases)
 
-📖 [文档](https://naiba.github.io/bonds/zh/) | [English](README.md)
+📖 [文档](https://naiba.github.io/bonds/zh/) | [English](README.md) | 💬 [Discord](https://discord.gg/faaEJyt4h)
 
 <a href="https://www.producthunt.com/products/bonds?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-bonds" target="_blank" rel="noopener noreferrer"><img alt="Bonds - Remember everything about the people who matter. | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1091729&amp;theme=light&amp;t=1772852214754"></a>
 


### PR DESCRIPTION
## Summary
- Add the Discord invite link from #112 to both English and Chinese README top navigation.

## Verification
- `rtk make gen-api`
- `cd server && GOPROXY=https://goproxy.cn,direct rtk go test ./... -count=1`
- `cd server && GOPROXY=https://goproxy.cn,direct rtk go build ./...`
- `cd web && bun run lint`
- `cd web && bun run test`
- `cd web && bun run build`
- `cd web && bunx playwright test` attempted locally after installing Chromium; local full E2E did not complete reliably due existing E2E timeouts/hangs unrelated to this README-only change, so CI is the source of truth.

Closes #112