### PR TITLE
fix: stabilize secret tamper and vault deletion

### DIFF
--- a/server/internal/services/admin.go
+++ b/server/internal/services/admin.go
@@ -234,6 +234,7 @@ func (s *AdminService) deleteEntireAccount(user models.User) error {
 		accountTables := []interface{}{
 			&models.Invitation{},
 			&models.AccountCurrency{},
+			&models.TaskStatus{},
 			&models.Gender{},
 			&models.Pronoun{},
 			&models.AddressType{},

--- a/server/internal/services/admin.go
+++ b/server/internal/services/admin.go
@@ -381,6 +381,7 @@ func (s *AdminService) deleteVaultData(tx *gorm.DB, vaultID string) error {
 		&models.AddressBookSubscription{},
 		&models.Address{},
 		&models.Loan{},
+		&models.ContactTask{},
 		&models.TimelineEvent{},
 		&models.LifeMetric{},
 	}

--- a/server/internal/services/admin_test.go
+++ b/server/internal/services/admin_test.go
@@ -2,8 +2,11 @@ package services
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
+	"github.com/naiba/bonds/internal/config"
+	"github.com/naiba/bonds/internal/database"
 	"github.com/naiba/bonds/internal/dto"
 	"github.com/naiba/bonds/internal/models"
 	"github.com/naiba/bonds/internal/testutil"
@@ -293,6 +296,41 @@ func TestAdminDeleteUser_Success(t *testing.T) {
 	adminSvc.db.Model(&models.ContactTask{}).Where("vault_id = ?", vault.ID).Count(&taskCount)
 	if taskCount != 0 {
 		t.Error("expected standalone vault tasks to be deleted")
+	}
+}
+
+func TestAdminDeleteUser_RegisteredUserWithDefaultVault(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := database.Connect(&config.DatabaseConfig{Driver: "sqlite", DSN: filepath.Join(tmpDir, "bonds.db")}, false)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	if err := database.AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+	adminSvc := NewAdminService(db, filepath.Join(tmpDir, "uploads"))
+	authSvc := NewAuthService(db, testutil.TestJWTConfig())
+
+	// The running server enables SQLite foreign keys; keep this regression aligned
+	// with the HTTP path so account cleanup cannot leave child rows behind.
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		t.Fatalf("Failed to enable foreign keys: %v", err)
+	}
+	if err := models.SeedCurrencies(db); err != nil {
+		t.Fatalf("SeedCurrencies failed: %v", err)
+	}
+
+	admin := registerTestUser(t, authSvc, "del-default-admin@example.com")
+	target := registerTestUser(t, authSvc, "del-default-target@example.com")
+
+	if err := adminSvc.DeleteUser(admin.User.ID, target.User.ID); err != nil {
+		t.Fatalf("DeleteUser failed: %v", err)
+	}
+
+	var userCount int64
+	adminSvc.db.Model(&models.User{}).Where("id = ?", target.User.ID).Count(&userCount)
+	if userCount != 0 {
+		t.Error("expected target user to be deleted")
 	}
 }
 

--- a/server/internal/services/admin_test.go
+++ b/server/internal/services/admin_test.go
@@ -255,6 +255,11 @@ func TestAdminDeleteUser_Success(t *testing.T) {
 		t.Fatalf("CreateContact failed: %v", err)
 	}
 
+	vaultTaskSvc := NewVaultTaskService(adminSvc.db)
+	if _, err := vaultTaskSvc.Create(vault.ID, target.User.ID, dto.CreateVaultTaskRequest{Label: "Standalone account task"}); err != nil {
+		t.Fatalf("Create standalone vault task failed: %v", err)
+	}
+
 	err = adminSvc.DeleteUser(admin.User.ID, target.User.ID)
 	if err != nil {
 		t.Fatalf("DeleteUser failed: %v", err)
@@ -282,6 +287,12 @@ func TestAdminDeleteUser_Success(t *testing.T) {
 	adminSvc.db.Model(&models.Contact{}).Where("vault_id = ?", vault.ID).Count(&contactCount)
 	if contactCount != 0 {
 		t.Error("expected contacts to be deleted")
+	}
+
+	var taskCount int64
+	adminSvc.db.Model(&models.ContactTask{}).Where("vault_id = ?", vault.ID).Count(&taskCount)
+	if taskCount != 0 {
+		t.Error("expected standalone vault tasks to be deleted")
 	}
 }
 

--- a/server/internal/services/vault.go
+++ b/server/internal/services/vault.go
@@ -321,7 +321,8 @@ func deleteVaultCascade(tx *gorm.DB, vaultID string) error {
 		&models.File{},
 		&models.Address{},
 		&models.LifeMetric{},
-		&models.Note{}, // Notes with vault_id but no contact (edge case safety)
+		&models.Note{},        // Notes with vault_id but no contact (edge case safety)
+		&models.ContactTask{}, // Standalone vault tasks have vault_id but no contact_id.
 		&models.ContactVaultUser{},
 		&models.UserVault{},
 	}

--- a/server/internal/services/vault_test.go
+++ b/server/internal/services/vault_test.go
@@ -351,6 +351,7 @@ func TestDeleteVault_CleanupCompleteness(t *testing.T) {
 		{"Address", &models.Address{}},
 		{"LifeMetric", &models.LifeMetric{}},
 		{"Note", &models.Note{}},
+		{"ContactTask", &models.ContactTask{}},
 		{"Journal", &models.Journal{}},
 		{"TimelineEvent", &models.TimelineEvent{}},
 		{"ContactVaultUser", &models.ContactVaultUser{}},
@@ -406,9 +407,21 @@ func TestDeleteVault_WithForeignKeysEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateVault failed: %v", err)
 	}
+	taskSvc := NewVaultTaskService(db)
+	if _, err := taskSvc.Create(vault.ID, resp.User.ID, dto.CreateVaultTaskRequest{
+		Label: "Standalone vault task",
+	}); err != nil {
+		t.Fatalf("Create standalone vault task failed: %v", err)
+	}
 
 	if err := vaultSvc.DeleteVault(vault.ID); err != nil {
 		t.Fatalf("DeleteVault with foreign_keys=ON failed: %v", err)
+	}
+
+	var taskCount int64
+	db.Model(&models.ContactTask{}).Where("vault_id = ?", vault.ID).Count(&taskCount)
+	if taskCount != 0 {
+		t.Errorf("Expected standalone vault tasks to be deleted, got %d", taskCount)
 	}
 
 	_, err = vaultSvc.GetVault(vault.ID, resp.User.ID)

--- a/server/pkg/secret/secret_test.go
+++ b/server/pkg/secret/secret_test.go
@@ -95,7 +95,7 @@ func TestDecryptCorruptedCiphertext(t *testing.T) {
 	c := New("k")
 	ct, _ := c.Encrypt("secret")
 
-	tampered := strings.TrimSuffix(ct, ct[len(ct)-1:]) + "0"
+	tampered := corruptCiphertextForTest(ct)
 	if _, err := c.Decrypt(tampered); err == nil {
 		t.Fatal("tampered ciphertext must fail GCM auth")
 	}
@@ -107,6 +107,25 @@ func TestDecryptCorruptedCiphertext(t *testing.T) {
 	if _, err := c.Decrypt(CiphertextPrefix + "00"); err == nil {
 		t.Fatal("ciphertext shorter than nonce must fail")
 	}
+}
+
+func TestCorruptCiphertextForTestAlwaysChangesCiphertext(t *testing.T) {
+	ciphertextEndingInZero := CiphertextPrefix + "abc0"
+
+	tampered := corruptCiphertextForTest(ciphertextEndingInZero)
+
+	if tampered == ciphertextEndingInZero {
+		t.Fatal("test tamper must modify ciphertext even when the original ends in 0")
+	}
+}
+
+func corruptCiphertextForTest(ciphertext string) string {
+	last := ciphertext[len(ciphertext)-1]
+	replacement := byte('0')
+	if last == replacement {
+		replacement = '1'
+	}
+	return strings.TrimSuffix(ciphertext, ciphertext[len(ciphertext)-1:]) + string(replacement)
 }
 
 func TestEncryptEmptyString(t *testing.T) {

--- a/web/src/pages/admin/Users.tsx
+++ b/web/src/pages/admin/Users.tsx
@@ -100,7 +100,21 @@ export default function AdminUsers() {
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.admin.usersDelete(id),
-    onSuccess: () => {
+    onSuccess: (_data, deletedUserID) => {
+      queryClient.setQueriesData<{
+        users: AdminUser[];
+        meta?: PaginationMeta;
+      }>({ queryKey: invalidateKey }, (oldData) => {
+        if (!oldData) return oldData;
+        const users = oldData.users.filter((user) => user.id !== deletedUserID);
+        return {
+          ...oldData,
+          users,
+          meta: oldData.meta
+            ? { ...oldData.meta, total: Math.max(0, (oldData.meta.total ?? users.length) - 1) }
+            : oldData.meta,
+        };
+      });
       queryClient.invalidateQueries({ queryKey: invalidateKey });
       message.success(t("admin.users.deleted"));
     },

--- a/web/src/test/AdminUsers.test.tsx
+++ b/web/src/test/AdminUsers.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { App as AntApp, ConfigProvider } from "antd";
 import AdminUsers from "@/pages/admin/Users";
+import { api } from "@/api";
 
 beforeAll(() => {
   globalThis.ResizeObserver = class {
@@ -34,10 +35,35 @@ vi.mock("@/stores/auth", () => ({
 }));
 
 const mockUseQuery = vi.fn();
+const mockSetQueriesData = vi.fn();
+const mockInvalidateQueries = vi.fn();
+const mutationOptions: Array<{
+  mutationFn: (variables: unknown) => Promise<unknown>;
+  onSuccess?: (data: unknown, variables: unknown) => void;
+  onError?: (error: unknown) => void;
+}> = [];
 vi.mock("@tanstack/react-query", () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
-  useMutation: () => ({ mutate: vi.fn(), isPending: false }),
-  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  useMutation: (options: {
+    mutationFn: (variables: unknown) => Promise<unknown>;
+    onSuccess?: (data: unknown, variables: unknown) => void;
+    onError?: (error: unknown) => void;
+  }) => {
+    mutationOptions.push(options);
+    return {
+      mutate: (variables: unknown) => {
+        options
+          .mutationFn(variables)
+          .then((data) => options.onSuccess?.(data, variables))
+          .catch((error) => options.onError?.(error));
+      },
+      isPending: false,
+    };
+  },
+  useQueryClient: () => ({
+    invalidateQueries: mockInvalidateQueries,
+    setQueriesData: mockSetQueriesData,
+  }),
 }));
 
 function renderAdminUsers() {
@@ -55,6 +81,8 @@ function renderAdminUsers() {
 describe("AdminUsers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mutationOptions.length = 0;
+    vi.mocked(api.admin.usersDelete).mockResolvedValue(undefined);
   });
 
   function mockUsersData(users: unknown[]) {
@@ -153,5 +181,61 @@ describe("AdminUsers", () => {
     renderAdminUsers();
     expect(screen.queryByText("Disable")).not.toBeInTheDocument();
     expect(screen.queryByText("Remove Admin")).not.toBeInTheDocument();
+  });
+
+  it("removes a deleted user from cached admin users data", () => {
+    mockUseQuery.mockReturnValue(
+      mockUsersData([
+        {
+          id: "admin-1",
+          first_name: "Self",
+          last_name: "Admin",
+          email: "self@example.com",
+          is_instance_administrator: true,
+          disabled: false,
+          contact_count: 0,
+          vault_count: 0,
+          storage_used: 0,
+          created_at: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "user-2",
+          first_name: "Throw",
+          last_name: "Away",
+          email: "throwaway@example.com",
+          is_instance_administrator: false,
+          disabled: false,
+          contact_count: 0,
+          vault_count: 0,
+          storage_used: 0,
+          created_at: "2024-01-02T00:00:00Z",
+        },
+      ]),
+    );
+
+    renderAdminUsers();
+
+    const deleteMutation = mutationOptions[2];
+    deleteMutation.onSuccess?.(undefined, "user-2");
+
+    expect(mockSetQueriesData).toHaveBeenCalledWith(
+      { queryKey: ["admin", "users"] },
+      expect.any(Function),
+    );
+
+    const updateCachedUsers = mockSetQueriesData.mock.calls[0][1] as (oldData: {
+      users: Array<{ id: string; email: string }>;
+      meta: { total: number };
+    }) => { users: Array<{ id: string; email: string }>; meta: { total: number } };
+    const updated = updateCachedUsers({
+      users: [
+        { id: "admin-1", email: "self@example.com" },
+        { id: "user-2", email: "throwaway@example.com" },
+      ],
+      meta: { total: 2 },
+    });
+
+    expect(updated.users).toEqual([{ id: "admin-1", email: "self@example.com" }]);
+    expect(updated.meta.total).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- Stabilize the corrupted ciphertext regression test by making test tampering always change the ciphertext.
- Delete standalone vault tasks during vault cascade cleanup.
- Add regression coverage for vault deletion with standalone tasks and FK enforcement.

## Verification
- `cd server && GOPROXY=https://goproxy.cn,direct rtk go test ./pkg/secret -run 'TestCorruptCiphertextForTestAlwaysChangesCiphertext|TestDecryptCorruptedCiphertext' -count=100`
- `cd server && GOPROXY=https://goproxy.cn,direct rtk go test ./internal/services -run TestDeleteVault_WithForeignKeysEnabled -count=1`
- `cd server && GOPROXY=https://goproxy.cn,direct rtk go test ./... -count=1`
- `cd server && GOPROXY=https://goproxy.cn,direct rtk go build ./...`

Fixes #108
Fixes #113