### PR TITLE
fix(quick-facts): show all contact fact categories

### DIFF
--- a/server/internal/dto/quick_facts.go
+++ b/server/internal/dto/quick_facts.go
@@ -18,3 +18,10 @@ type QuickFactResponse struct {
 	CreatedAt                 time.Time `json:"created_at" example:"2026-01-15T10:30:00Z"`
 	UpdatedAt                 time.Time `json:"updated_at" example:"2026-01-15T10:30:00Z"`
 }
+
+type QuickFactGroupResponse struct {
+	TemplateID    uint                `json:"template_id" example:"1"`
+	TemplateLabel string              `json:"template_label" example:"Hobbies"`
+	Position      int                 `json:"position" example:"1"`
+	Facts         []QuickFactResponse `json:"facts"`
+}

--- a/server/internal/handlers/quick_facts.go
+++ b/server/internal/handlers/quick_facts.go
@@ -18,6 +18,32 @@ func NewQuickFactHandler(quickFactService *services.QuickFactService) *QuickFact
 	return &QuickFactHandler{quickFactService: quickFactService}
 }
 
+// ListAll godoc
+//
+//	@Summary		List all quick facts
+//	@Description	Return all quick facts for a contact grouped by vault template
+//	@Tags			quick-facts
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			vault_id	path		string	true	"Vault ID"
+//	@Param			contact_id	path		string	true	"Contact ID"
+//	@Success		200			{object}	response.APIResponse{data=[]dto.QuickFactGroupResponse}
+//	@Failure		404			{object}	response.APIResponse
+//	@Failure		500			{object}	response.APIResponse
+//	@Router			/vaults/{vault_id}/contacts/{contact_id}/quickFacts [get]
+func (h *QuickFactHandler) ListAll(c echo.Context) error {
+	contactID := c.Param("contact_id")
+	vaultID := c.Param("vault_id")
+	facts, err := h.quickFactService.ListAll(contactID, vaultID)
+	if err != nil {
+		if errors.Is(err, services.ErrContactNotFound) {
+			return response.NotFound(c, "err.contact_not_found")
+		}
+		return response.InternalError(c, "err.failed_to_list_quick_facts")
+	}
+	return response.OK(c, facts)
+}
+
 // List godoc
 //
 //	@Summary		List quick facts
@@ -44,6 +70,9 @@ func (h *QuickFactHandler) List(c echo.Context) error {
 	if err != nil {
 		if errors.Is(err, services.ErrContactNotFound) {
 			return response.NotFound(c, "err.contact_not_found")
+		}
+		if errors.Is(err, services.ErrQuickFactTplNotFound) {
+			return response.NotFound(c, "err.quick_fact_template_not_found")
 		}
 		return response.InternalError(c, "err.failed_to_list_quick_facts")
 	}
@@ -85,6 +114,9 @@ func (h *QuickFactHandler) Create(c echo.Context) error {
 	if err != nil {
 		if errors.Is(err, services.ErrContactNotFound) {
 			return response.NotFound(c, "err.contact_not_found")
+		}
+		if errors.Is(err, services.ErrQuickFactTplNotFound) {
+			return response.NotFound(c, "err.quick_fact_template_not_found")
 		}
 		return response.InternalError(c, "err.failed_to_create_quick_fact")
 	}

--- a/server/internal/handlers/routes.go
+++ b/server/internal/handlers/routes.go
@@ -477,6 +477,7 @@ func RegisterRoutes(e *echo.Echo, db *gorm.DB, cfg *config.Config, version strin
 	contactSub.PUT("/quickFacts/toggle", quickFactHandler.Toggle, requireEditor)
 
 	quickFactRoutes := contactSub.Group("/quickFacts")
+	quickFactRoutes.GET("", quickFactHandler.ListAll)
 	quickFactRoutes.GET("/:templateId", quickFactHandler.List)
 	quickFactRoutes.POST("/:templateId", quickFactHandler.Create, requireEditor)
 	quickFactRoutes.PUT("/:templateId/:id", quickFactHandler.Update, requireEditor)

--- a/server/internal/services/quick_facts.go
+++ b/server/internal/services/quick_facts.go
@@ -22,6 +22,9 @@ func (s *QuickFactService) List(contactID, vaultID string, templateID uint) ([]d
 	if err := validateContactBelongsToVault(s.db, contactID, vaultID); err != nil {
 		return nil, err
 	}
+	if err := s.validateTemplateBelongsToVault(templateID, vaultID); err != nil {
+		return nil, err
+	}
 	var facts []models.QuickFact
 	if err := s.db.Where("contact_id = ? AND vault_quick_facts_template_id = ?", contactID, templateID).
 		Order("created_at DESC").Find(&facts).Error; err != nil {
@@ -34,8 +37,49 @@ func (s *QuickFactService) List(contactID, vaultID string, templateID uint) ([]d
 	return result, nil
 }
 
+func (s *QuickFactService) ListAll(contactID, vaultID string) ([]dto.QuickFactGroupResponse, error) {
+	if err := validateContactBelongsToVault(s.db, contactID, vaultID); err != nil {
+		return nil, err
+	}
+
+	var templates []models.VaultQuickFactsTemplate
+	if err := s.db.Where("vault_id = ?", vaultID).Order("position ASC, id ASC").Find(&templates).Error; err != nil {
+		return nil, err
+	}
+
+	var facts []models.QuickFact
+	if err := s.db.Joins("JOIN vault_quick_facts_templates ON vault_quick_facts_templates.id = quick_facts.vault_quick_facts_template_id").
+		Where("quick_facts.contact_id = ? AND vault_quick_facts_templates.vault_id = ?", contactID, vaultID).
+		Order("quick_facts.created_at DESC").
+		Find(&facts).Error; err != nil {
+		return nil, err
+	}
+
+	factsByTemplateID := make(map[uint][]dto.QuickFactResponse, len(templates))
+	for _, fact := range facts {
+		factsByTemplateID[fact.VaultQuickFactsTemplateID] = append(factsByTemplateID[fact.VaultQuickFactsTemplateID], toQuickFactResponse(&fact))
+	}
+
+	groups := make([]dto.QuickFactGroupResponse, len(templates))
+	for i, template := range templates {
+		groups[i] = dto.QuickFactGroupResponse{
+			TemplateID:    template.ID,
+			TemplateLabel: ptrToStr(template.Label),
+			Position:      template.Position,
+			Facts:         factsByTemplateID[template.ID],
+		}
+		if groups[i].Facts == nil {
+			groups[i].Facts = []dto.QuickFactResponse{}
+		}
+	}
+	return groups, nil
+}
+
 func (s *QuickFactService) Create(contactID, vaultID string, templateID uint, req dto.CreateQuickFactRequest) (*dto.QuickFactResponse, error) {
 	if err := validateContactBelongsToVault(s.db, contactID, vaultID); err != nil {
+		return nil, err
+	}
+	if err := s.validateTemplateBelongsToVault(templateID, vaultID); err != nil {
 		return nil, err
 	}
 	fact := models.QuickFact{
@@ -55,7 +99,9 @@ func (s *QuickFactService) Update(id uint, contactID, vaultID string, req dto.Up
 		return nil, err
 	}
 	var fact models.QuickFact
-	if err := s.db.Where("id = ? AND contact_id = ?", id, contactID).First(&fact).Error; err != nil {
+	if err := s.db.Joins("JOIN vault_quick_facts_templates ON vault_quick_facts_templates.id = quick_facts.vault_quick_facts_template_id").
+		Where("quick_facts.id = ? AND quick_facts.contact_id = ? AND vault_quick_facts_templates.vault_id = ?", id, contactID, vaultID).
+		First(&fact).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrQuickFactNotFound
 		}
@@ -74,13 +120,26 @@ func (s *QuickFactService) Delete(id uint, contactID, vaultID string) error {
 		return err
 	}
 	var fact models.QuickFact
-	if err := s.db.Where("id = ? AND contact_id = ?", id, contactID).First(&fact).Error; err != nil {
+	if err := s.db.Joins("JOIN vault_quick_facts_templates ON vault_quick_facts_templates.id = quick_facts.vault_quick_facts_template_id").
+		Where("quick_facts.id = ? AND quick_facts.contact_id = ? AND vault_quick_facts_templates.vault_id = ?", id, contactID, vaultID).
+		First(&fact).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return ErrQuickFactNotFound
 		}
 		return err
 	}
 	return s.db.Delete(&fact).Error
+}
+
+func (s *QuickFactService) validateTemplateBelongsToVault(templateID uint, vaultID string) error {
+	var template models.VaultQuickFactsTemplate
+	if err := s.db.Where("id = ? AND vault_id = ?", templateID, vaultID).First(&template).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrQuickFactTplNotFound
+		}
+		return err
+	}
+	return nil
 }
 
 func toQuickFactResponse(f *models.QuickFact) dto.QuickFactResponse {

--- a/server/internal/services/quick_facts_test.go
+++ b/server/internal/services/quick_facts_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/naiba/bonds/internal/dto"
+	"github.com/naiba/bonds/internal/models"
 	"github.com/naiba/bonds/internal/testutil"
 )
 
@@ -79,6 +80,47 @@ func TestListQuickFacts(t *testing.T) {
 	}
 	if len(facts) != 2 {
 		t.Errorf("Expected 2 quick facts, got %d", len(facts))
+	}
+}
+
+func TestListAllQuickFactsGroupsFactsByVaultTemplate(t *testing.T) {
+	svc, contactID, vaultID := setupQuickFactTest(t)
+
+	var templates []models.VaultQuickFactsTemplate
+	if err := svc.db.Where("vault_id = ?", vaultID).Order("position ASC").Find(&templates).Error; err != nil {
+		t.Fatalf("List templates failed: %v", err)
+	}
+	if len(templates) < 2 {
+		t.Fatalf("Expected at least 2 quick fact templates, got %d", len(templates))
+	}
+
+	_, err := svc.Create(contactID, vaultID, templates[0].ID, dto.CreateQuickFactRequest{Content: "Enjoys hiking"})
+	if err != nil {
+		t.Fatalf("Create first template fact failed: %v", err)
+	}
+	_, err = svc.Create(contactID, vaultID, templates[1].ID, dto.CreateQuickFactRequest{Content: "Avoids caffeine"})
+	if err != nil {
+		t.Fatalf("Create second template fact failed: %v", err)
+	}
+
+	groups, err := svc.ListAll(contactID, vaultID)
+	if err != nil {
+		t.Fatalf("ListAll failed: %v", err)
+	}
+	if len(groups) != len(templates) {
+		t.Fatalf("Expected %d template groups, got %d", len(templates), len(groups))
+	}
+	if groups[0].TemplateID != templates[0].ID {
+		t.Errorf("Expected first template ID %d, got %d", templates[0].ID, groups[0].TemplateID)
+	}
+	if groups[0].TemplateLabel == "" {
+		t.Error("Expected first template label to be populated")
+	}
+	if len(groups[0].Facts) != 1 || groups[0].Facts[0].Content != "Enjoys hiking" {
+		t.Fatalf("Expected first group to contain hiking fact, got %+v", groups[0].Facts)
+	}
+	if len(groups[1].Facts) != 1 || groups[1].Facts[0].Content != "Avoids caffeine" {
+		t.Fatalf("Expected second group to contain caffeine fact, got %+v", groups[1].Facts)
 	}
 }
 

--- a/web/e2e/quick-facts.spec.ts
+++ b/web/e2e/quick-facts.spec.ts
@@ -74,6 +74,7 @@ test.describe('Contact Modules - Quick Facts', () => {
     expect(resp.status()).toBeLessThan(400);
 
     await expect(qfCard.getByText('Loves hiking')).toBeVisible({ timeout: 10000 });
+    await expect(qfCard.getByText('Hobbies')).toBeVisible({ timeout: 10000 });
 
     // --- UPDATE: Edit the quick fact ---
     await qfCard.getByRole('button', { name: /edit/i }).first().click();

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,5 +1,26 @@
 import { defineConfig, devices } from '@playwright/test';
 
+function readPortEnv(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${name} must be a decimal port number`);
+  }
+
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`${name} must be between 1 and 65535`);
+  }
+
+  return port;
+}
+
+const serverPort = readPortEnv('PLAYWRIGHT_SERVER_PORT', 8080);
+const vitePort = readPortEnv('PLAYWRIGHT_VITE_PORT', 5173);
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -9,7 +30,7 @@ export default defineConfig({
   workers: 1,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: `http://localhost:${vitePort}`,
     trace: 'on-first-retry',
   },
   projects: [
@@ -20,13 +41,13 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: 'rm -f ../server/bonds.db ../server/bonds.db-shm ../server/bonds.db-wal && cd ../server && go run -ldflags="-X main.Version=e2e-test" cmd/server/main.go',
-      port: 8080,
+      command: `rm -f ../server/bonds.db ../server/bonds.db-shm ../server/bonds.db-wal && cd ../server && SERVER_PORT=${serverPort} go run -ldflags="-X main.Version=e2e-test" cmd/server/main.go`,
+      port: serverPort,
       reuseExistingServer: !process.env.CI,
     },
     {
-      command: 'bun dev',
-      port: 5173,
+      command: `bun dev --host 0.0.0.0 --port ${vitePort}`,
+      port: vitePort,
       reuseExistingServer: !process.env.CI,
     },
   ],

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -280,6 +280,7 @@ export type { GithubComNaibaBondsInternalDtoLifeEventResponse as LifeEvent } fro
 export type { GithubComNaibaBondsInternalDtoMoodTrackingEventResponse as MoodTrackingEvent } from "./generated/data-contracts";
 export type { GithubComNaibaBondsInternalDtoMoodTrackingParameterResponse as MoodTrackingParameter } from "./generated/data-contracts";
 export type { GithubComNaibaBondsInternalDtoQuickFactResponse as QuickFact } from "./generated/data-contracts";
+export type { GithubComNaibaBondsInternalDtoQuickFactGroupResponse as QuickFactGroup } from "./generated/data-contracts";
 export type { GithubComNaibaBondsInternalDtoVaultFileResponse as Photo } from "./generated/data-contracts";
 export type { GithubComNaibaBondsInternalDtoVaultFileResponse as Document } from "./generated/data-contracts";
 export type { GithubComNaibaBondsInternalDtoJournalResponse as Journal } from "./generated/data-contracts";

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -800,11 +800,15 @@
     "quick_facts": {
       "title": "Quick Facts",
       "add": "Add",
+      "category_placeholder": "Select a category",
       "content_placeholder": "Content",
       "no_facts": "No quick facts",
       "delete_confirm": "Delete?",
       "toggle": "Toggle visibility",
-      "toggled": "Visibility updated"
+      "toggled": "Visibility updated",
+      "select_category_required": "Please select a quick fact category",
+      "missing_fact_reference": "Quick fact is missing its category",
+      "untitled_category": "Untitled category"
     },
     "relationships": {
       "title": "Relationships",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -800,11 +800,15 @@
     "quick_facts": {
       "title": "速览",
       "add": "添加",
+      "category_placeholder": "选择分类",
       "content_placeholder": "内容",
       "no_facts": "暂无速览",
       "delete_confirm": "确定删除？",
       "toggle": "切换可见性",
-      "toggled": "可见性已更新"
+      "toggled": "可见性已更新",
+      "select_category_required": "请选择速览分类",
+      "missing_fact_reference": "此速览缺少分类",
+      "untitled_category": "未命名分类"
     },
     "relationships": {
       "title": "关系",

--- a/web/src/pages/contact/ContactDetail.tsx
+++ b/web/src/pages/contact/ContactDetail.tsx
@@ -335,7 +335,7 @@ export default function ContactDetail() {
       }
       if (isContactPage && moduleType === "quick_facts") {
         children.push(
-          <QuickFactsModule key={`mod-${mod.id}`} {...moduleProps} templateId={tabsData?.template_id ?? 1} />,
+          <QuickFactsModule key={`mod-${mod.id}`} {...moduleProps} />,
         );
         continue;
       }
@@ -384,7 +384,7 @@ export default function ContactDetail() {
         <Space direction="vertical" style={{ width: "100%" }} size={16}>
           {overviewCard}
           <LabelsModule {...moduleProps} />
-          <QuickFactsModule {...moduleProps} templateId={1} />
+          <QuickFactsModule {...moduleProps} />
           <NotesModule {...moduleProps} />
         </Space>
       ),

--- a/web/src/pages/contact/modules/QuickFactsModule.tsx
+++ b/web/src/pages/contact/modules/QuickFactsModule.tsx
@@ -1,35 +1,39 @@
 import { useState } from "react";
 import {
-  Card,
-  List,
-  Button,
-  Input,
-  Space,
-  Popconfirm,
   App,
+  Button,
+  Card,
   Empty,
-  theme,
+  Input,
+  Popconfirm,
+  Select,
+  Space,
   Tooltip,
+  Typography,
+  theme,
 } from "antd";
-import { PlusOutlined, DeleteOutlined, EditOutlined, EyeOutlined, EyeInvisibleOutlined } from "@ant-design/icons";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/api";
-import type { QuickFact, APIError } from "@/api";
+import {
+  DeleteOutlined,
+  EditOutlined,
+  EyeInvisibleOutlined,
+  EyeOutlined,
+  PlusOutlined,
+} from "@ant-design/icons";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-
-
+import { api } from "@/api";
+import type { APIError, QuickFact, QuickFactGroup } from "@/api";
 
 export default function QuickFactsModule({
   vaultId,
   contactId,
-  templateId = 1,
 }: {
   vaultId: string | number;
   contactId: string | number;
-  templateId?: number;
 }) {
   const [adding, setAdding] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<number | null>(null);
   const [content, setContent] = useState("");
   const [isCollapsed, setIsCollapsed] = useState(false);
 
@@ -37,23 +41,38 @@ export default function QuickFactsModule({
   const { message } = App.useApp();
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const qk = ["vaults", vaultId, "contacts", contactId, "quickFacts", templateId];
+  const qk = ["vaults", vaultId, "contacts", contactId, "quickFacts"];
 
-  const { data: facts = [], isLoading } = useQuery({
+  const { data: groups = [], isLoading } = useQuery({
     queryKey: qk,
     queryFn: async () => {
-      const res = await api.quickFacts.contactsQuickFactsDetail(String(vaultId), String(contactId), templateId);
+      const res = await api.quickFacts.contactsQuickFactsList(String(vaultId), String(contactId));
       return res.data ?? [];
     },
   });
 
+  const quickFactGroups: QuickFactGroup[] = groups;
+
+  const editableGroups = quickFactGroups.filter((group) => group.template_id !== undefined);
+  const visibleGroups = quickFactGroups.filter((group) => (group.facts?.length ?? 0) > 0);
+  const hasFacts = visibleGroups.length > 0;
+
   const saveMutation = useMutation({
     mutationFn: () => {
+      if (!selectedTemplateId) {
+        return Promise.reject({ message: t("modules.quick_facts.select_category_required") });
+      }
       const data = { content };
       if (editingId) {
-        return api.quickFacts.contactsQuickFactsUpdate(String(vaultId), String(contactId), templateId, editingId, data);
+        return api.quickFacts.contactsQuickFactsUpdate(
+          String(vaultId),
+          String(contactId),
+          selectedTemplateId,
+          editingId,
+          data,
+        );
       }
-      return api.quickFacts.contactsQuickFactsCreate(String(vaultId), String(contactId), templateId, data);
+      return api.quickFacts.contactsQuickFactsCreate(String(vaultId), String(contactId), selectedTemplateId, data);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: qk });
@@ -63,7 +82,17 @@ export default function QuickFactsModule({
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: number) => api.quickFacts.contactsQuickFactsDelete(String(vaultId), String(contactId), templateId, id),
+    mutationFn: (fact: QuickFact) => {
+      if (!fact.id || !fact.vault_quick_facts_template_id) {
+        return Promise.reject({ message: t("modules.quick_facts.missing_fact_reference") });
+      }
+      return api.quickFacts.contactsQuickFactsDelete(
+        String(vaultId),
+        String(contactId),
+        fact.vault_quick_facts_template_id,
+        fact.id,
+      );
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: qk });
     },
@@ -71,24 +100,37 @@ export default function QuickFactsModule({
   });
 
   const toggleMutation = useMutation({
-      mutationFn: () => api.quickFacts.contactsQuickFactsToggleUpdate(String(vaultId), String(contactId)),
-      onSuccess: () => {
-          setIsCollapsed(!isCollapsed);
-          message.success(t("modules.quick_facts.toggled"));
-      },
-      onError: (e: APIError) => message.error(e.message),
+    mutationFn: () => api.quickFacts.contactsQuickFactsToggleUpdate(String(vaultId), String(contactId)),
+    onSuccess: () => {
+      setIsCollapsed(!isCollapsed);
+      message.success(t("modules.quick_facts.toggled"));
+    },
+    onError: (e: APIError) => message.error(e.message),
   });
 
   function resetForm() {
     setAdding(false);
     setEditingId(null);
+    setSelectedTemplateId(null);
+    setContent("");
+  }
+
+  function startAdd() {
+    setAdding(true);
+    setEditingId(null);
+    setSelectedTemplateId(editableGroups[0]?.template_id ?? null);
     setContent("");
   }
 
   function startEdit(fact: QuickFact) {
     setEditingId(fact.id ?? null);
-    setContent(fact.content ?? '');
+    setSelectedTemplateId(fact.vault_quick_facts_template_id ?? null);
+    setContent(fact.content ?? "");
     setAdding(false);
+  }
+
+  function groupLabel(group: QuickFactGroup) {
+    return group.template_label || t("modules.quick_facts.untitled_category");
   }
 
   const showForm = adding || editingId !== null;
@@ -98,78 +140,116 @@ export default function QuickFactsModule({
       title={<span style={{ fontWeight: 500 }}>{t("modules.quick_facts.title")}</span>}
       styles={{
         header: { borderBottom: `1px solid ${token.colorBorderSecondary}` },
-        body: { padding: isCollapsed ? 0 : '16px 24px', display: isCollapsed ? 'none' : 'block' },
+        body: { padding: isCollapsed ? 0 : "16px 24px", display: isCollapsed ? "none" : "block" },
       }}
       extra={
         <Space>
-            <Tooltip title={t("modules.quick_facts.toggle")}>
-                <Button 
-                    type="text" 
-                    icon={isCollapsed ? <EyeInvisibleOutlined /> : <EyeOutlined />} 
-                    onClick={() => toggleMutation.mutate()} 
-                />
-            </Tooltip>
-            {!showForm && (
-            <Button type="text" icon={<PlusOutlined />} onClick={() => setAdding(true)} style={{ color: token.colorPrimary }}>
-                {t("modules.quick_facts.add")}
+          <Tooltip title={t("modules.quick_facts.toggle")}>
+            <Button
+              type="text"
+              icon={isCollapsed ? <EyeInvisibleOutlined /> : <EyeOutlined />}
+              onClick={() => toggleMutation.mutate()}
+            />
+          </Tooltip>
+          {!showForm && (
+            <Button type="text" icon={<PlusOutlined />} onClick={startAdd} style={{ color: token.colorPrimary }}>
+              {t("modules.quick_facts.add")}
             </Button>
-            )}
+          )}
         </Space>
       }
     >
       {showForm && (
-        <div style={{
-          marginBottom: 16,
-          padding: 16,
-          background: token.colorFillQuaternary,
-          borderRadius: token.borderRadius,
-        }}>
-          <Space orientation="vertical" style={{ width: "100%" }}>
-            <Input placeholder={t("modules.quick_facts.content_placeholder")} value={content} onChange={(e) => setContent(e.target.value)} />
+        <div
+          style={{
+            marginBottom: 16,
+            padding: 16,
+            background: token.colorFillQuaternary,
+            borderRadius: token.borderRadius,
+          }}
+        >
+          <Space direction="vertical" style={{ width: "100%" }}>
+            <Select
+              placeholder={t("modules.quick_facts.category_placeholder")}
+              value={selectedTemplateId ?? undefined}
+              onChange={setSelectedTemplateId}
+              disabled={editingId !== null}
+              options={editableGroups.map((group) => ({
+                label: groupLabel(group),
+                value: group.template_id,
+              }))}
+            />
+            <Input
+              placeholder={t("modules.quick_facts.content_placeholder")}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+            />
             <Space>
               <Button
                 type="primary"
                 onClick={() => saveMutation.mutate()}
                 loading={saveMutation.isPending}
-                disabled={!content.trim()}
+                disabled={!content.trim() || !selectedTemplateId}
                 size="small"
               >
                 {editingId ? t("common.update") : t("common.save")}
               </Button>
-              <Button onClick={resetForm} size="small">{t("common.cancel")}</Button>
+              <Button onClick={resetForm} size="small">
+                {t("common.cancel")}
+              </Button>
             </Space>
           </Space>
         </div>
       )}
 
-      <List
-        loading={isLoading}
-        dataSource={facts}
-        locale={{ emptyText: <Empty description={t("modules.quick_facts.no_facts")} /> }}
-        split={false}
-        renderItem={(fact: QuickFact) => (
-          <List.Item
-            style={{
-              borderRadius: token.borderRadius,
-              padding: '10px 12px',
-              marginBottom: 4,
-              transition: 'background 0.2s',
-            }}
-            onMouseEnter={(e) => { e.currentTarget.style.background = token.colorFillQuaternary; }}
-            onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
-            actions={[
-              <Button key="e" type="text" size="small" icon={<EditOutlined />} onClick={() => startEdit(fact)} />,
-              <Popconfirm key="d" title={t("modules.quick_facts.delete_confirm")} onConfirm={() => deleteMutation.mutate(fact.id!)}>
-                <Button type="text" size="small" danger icon={<DeleteOutlined />} />
-              </Popconfirm>,
-            ]}
-          >
-            <List.Item.Meta
-              title={<span style={{ fontWeight: 500 }}>{fact.content}</span>}
-            />
-          </List.Item>
-        )}
-      />
+      {isLoading ? (
+        <Typography.Text type="secondary">{t("common.loading")}</Typography.Text>
+      ) : !hasFacts ? (
+        <Empty description={t("modules.quick_facts.no_facts")} />
+      ) : (
+        <Space direction="vertical" size={16} style={{ width: "100%" }}>
+          {visibleGroups.map((group) => (
+            <div key={group.template_id}>
+              <Typography.Text
+                type="secondary"
+                style={{ fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: 0.4 }}
+              >
+                {groupLabel(group)}
+              </Typography.Text>
+              <Space direction="vertical" size={4} style={{ width: "100%", marginTop: 8 }}>
+                {(group.facts ?? []).map((fact) => (
+                  <div
+                    key={fact.id}
+                    style={{
+                      borderRadius: token.borderRadius,
+                      padding: "10px 12px",
+                      transition: "background 0.2s",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      gap: 12,
+                    }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.background = token.colorFillQuaternary;
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.background = "transparent";
+                    }}
+                  >
+                    <Typography.Text style={{ fontWeight: 500 }}>{fact.content}</Typography.Text>
+                    <Space size={0}>
+                      <Button type="text" size="small" icon={<EditOutlined />} onClick={() => startEdit(fact)} />
+                      <Popconfirm title={t("modules.quick_facts.delete_confirm")} onConfirm={() => deleteMutation.mutate(fact)}>
+                        <Button type="text" size="small" danger icon={<DeleteOutlined />} />
+                      </Popconfirm>
+                    </Space>
+                  </div>
+                ))}
+              </Space>
+            </div>
+          ))}
+        </Space>
+      )}
     </Card>
   );
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     allowedHosts: true,
     proxy: {
       "/api": {
-        target: "http://localhost:8080",
+        target: `http://localhost:${process.env.PLAYWRIGHT_SERVER_PORT ?? "8080"}`,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
- add a grouped Quick Facts endpoint that returns all vault quick fact templates with the contact's facts
- remove the contact page dependency on hardcoded `templateId={1}`
- show Quick Facts by visible category/template and require category selection when adding a fact
- add E2E coverage for grouped category display and validate configurable Playwright ports

## Verification
- `GOPROXY=https://goproxy.cn,direct go test ./internal/services -run 'Test(ListAllQuickFactsGroupsFactsByVaultTemplate|CreateQuickFact|ListQuickFacts|UpdateQuickFact|DeleteQuickFact)' -count=1`
- `GOPROXY=https://goproxy.cn,direct go test ./internal/handlers -run QuickFact -count=1`
- `GOPROXY=https://goproxy.cn,direct go build ./...`
- `bun run lint`
- `bun run test -- src/test/ContactDetail.test.tsx`
- `bun run build`
- `PLAYWRIGHT_SERVER_PORT=18080 PLAYWRIGHT_VITE_PORT=15173 bunx playwright test e2e/quick-facts.spec.ts`

## Review notes
- security review found one blocking Playwright port interpolation issue; fixed by validating port env vars before shell interpolation
- LSP diagnostics could not run because `gopls` and `typescript-language-server` are not installed in this environment