### PR TITLE
feat(contacts): add 'needs verification' flag

### DIFF
--- a/server/internal/dto/contact.go
+++ b/server/internal/dto/contact.go
@@ -15,8 +15,7 @@ type CreateContactRequest struct {
 	TemplateID *uint  `json:"template_id" example:"1"`
 	Listed     *bool  `json:"listed" example:"true"`
 	// NeedsVerification flags a contact as needing later review (e.g. captured quickly
-	// or created by an automated agent). When nil, the server picks a default based on
-	// the auth context: true for API-token callers, false for web-session callers.
+	// or created by an automated agent). When nil, defaults to false.
 	NeedsVerification *bool `json:"needs_verification" example:"false"`
 }
 

--- a/server/internal/dto/contact.go
+++ b/server/internal/dto/contact.go
@@ -14,6 +14,10 @@ type CreateContactRequest struct {
 	PronounID  *uint  `json:"pronoun_id" example:"1"`
 	TemplateID *uint  `json:"template_id" example:"1"`
 	Listed     *bool  `json:"listed" example:"true"`
+	// NeedsVerification flags a contact as needing later review (e.g. captured quickly
+	// or created by an automated agent). When nil, the server picks a default based on
+	// the auth context: true for API-token callers, false for web-session callers.
+	NeedsVerification *bool `json:"needs_verification" example:"false"`
 }
 
 type UpdateContactRequest struct {
@@ -27,6 +31,7 @@ type UpdateContactRequest struct {
 	GenderID   *uint  `json:"gender_id" example:"1"`
 	PronounID  *uint  `json:"pronoun_id" example:"1"`
 	TemplateID *uint  `json:"template_id" example:"1"`
+	NeedsVerification *bool `json:"needs_verification" example:"false"`
 }
 
 type ContactResponse struct {
@@ -50,6 +55,7 @@ type ContactResponse struct {
 	ShowQuickFacts bool                `json:"show_quick_facts" example:"false"`
 	IsArchived     bool                `json:"is_archived" example:"false"`
 	IsFavorite     bool                `json:"is_favorite" example:"true"`
+	NeedsVerification bool             `json:"needs_verification" example:"false"`
 	CreatedAt      time.Time           `json:"created_at" example:"2026-01-15T10:30:00Z"`
 	UpdatedAt      time.Time           `json:"updated_at" example:"2026-01-15T10:30:00Z"`
 	Birthday       *string             `json:"birthday,omitempty" example:"1990-06-15"`

--- a/server/internal/handlers/contact.go
+++ b/server/internal/handlers/contact.go
@@ -31,7 +31,7 @@ func NewContactHandler(contactService *services.ContactService) *ContactHandler 
 //	@Param			per_page	query		integer	false	"Items per page"
 //	@Param			search		query		string	false	"Search term"
 //	@Param			sort		query		string	false	"Sort order: first_name, last_name, created_at, updated_at (default)"
-//	@Param			filter		query		string	false	"Filter: active (default), archived, all, favorites"
+//	@Param			filter		query		string	false	"Filter: active (default), archived, all, favorites, needs_verification"
 //	@Success		200			{object}	response.APIResponse{data=[]dto.ContactResponse}
 //	@Failure		401			{object}	response.APIResponse
 //	@Failure		500			{object}	response.APIResponse
@@ -64,7 +64,7 @@ func (h *ContactHandler) List(c echo.Context) error {
 //	@Param			page		query		integer	false	"Page number"
 //	@Param			per_page	query		integer	false	"Items per page"
 //	@Param			sort		query		string	false	"Sort order: first_name, last_name, created_at, updated_at (default)"
-//	@Param			filter		query		string	false	"Filter: active (default), archived, all, favorites"
+//	@Param			filter		query		string	false	"Filter: active (default), archived, all, favorites, needs_verification"
 //	@Success		200			{object}	response.APIResponse{data=[]dto.ContactResponse}
 //	@Failure		400			{object}	response.APIResponse
 //	@Failure		401			{object}	response.APIResponse

--- a/server/internal/models/contact.go
+++ b/server/internal/models/contact.go
@@ -27,6 +27,7 @@ type Contact struct {
 	CanBeDeleted   bool           `json:"can_be_deleted" gorm:"default:true"`
 	ShowQuickFacts bool           `json:"show_quick_facts" gorm:"default:false"`
 	Listed         bool           `json:"listed" gorm:"default:true"`
+	NeedsVerification bool        `json:"needs_verification" gorm:"default:false;index"`
 	Vcard          *string        `json:"vcard" gorm:"type:text"`
 	DistantUUID    *string        `json:"distant_uuid" gorm:"size:256"`
 	DistantEtag    *string        `json:"distant_etag" gorm:"size:256"`

--- a/server/internal/services/contact.go
+++ b/server/internal/services/contact.go
@@ -52,7 +52,8 @@ func (s *ContactService) ListContacts(vaultID, userID string, page, perPage int,
 		query = query.Where("listed = ?", true)
 		query = query.Where("id IN (SELECT contact_id FROM contact_vault_user WHERE user_id = ? AND is_favorite = ?)", userID, true)
 	case "needs_verification":
-		query = query.Where("listed = ?", true)
+		// Spans active and archived: a contact flagged for verification should
+		// remain discoverable even if the user archived it before reviewing.
 		query = query.Where("needs_verification = ?", true)
 	default: // "active" or empty
 		query = query.Where("listed = ?", true)
@@ -328,7 +329,8 @@ func (s *ContactService) ListContactsByLabel(vaultID, userID string, labelID uin
 		query = query.Where("listed = ?", true)
 		query = query.Where("id IN (SELECT contact_id FROM contact_vault_user WHERE user_id = ? AND is_favorite = ?)", userID, true)
 	case "needs_verification":
-		query = query.Where("listed = ?", true)
+		// Spans active and archived: a contact flagged for verification should
+		// remain discoverable even if the user archived it before reviewing.
 		query = query.Where("needs_verification = ?", true)
 	default: // "active" or empty
 		query = query.Where("listed = ?", true)

--- a/server/internal/services/contact.go
+++ b/server/internal/services/contact.go
@@ -51,6 +51,9 @@ func (s *ContactService) ListContacts(vaultID, userID string, page, perPage int,
 	case "favorites":
 		query = query.Where("listed = ?", true)
 		query = query.Where("id IN (SELECT contact_id FROM contact_vault_user WHERE user_id = ? AND is_favorite = ?)", userID, true)
+	case "needs_verification":
+		query = query.Where("listed = ?", true)
+		query = query.Where("needs_verification = ?", true)
 	default: // "active" or empty
 		query = query.Where("listed = ?", true)
 	}
@@ -123,6 +126,9 @@ func (s *ContactService) CreateContact(vaultID, userID string, req dto.CreateCon
 		PronounID:     req.PronounID,
 		TemplateID:    req.TemplateID,
 		LastUpdatedAt: &now,
+	}
+	if req.NeedsVerification != nil {
+		contact.NeedsVerification = *req.NeedsVerification
 	}
 
 	err := s.db.Transaction(func(tx *gorm.DB) error {
@@ -205,6 +211,9 @@ func (s *ContactService) UpdateContact(contactID, vaultID string, req dto.Update
 	contact.PronounID = req.PronounID
 	contact.TemplateID = req.TemplateID
 	contact.LastUpdatedAt = &now
+	if req.NeedsVerification != nil {
+		contact.NeedsVerification = *req.NeedsVerification
+	}
 
 	if err := s.db.Save(&contact).Error; err != nil {
 		return nil, err
@@ -318,6 +327,9 @@ func (s *ContactService) ListContactsByLabel(vaultID, userID string, labelID uin
 	case "favorites":
 		query = query.Where("listed = ?", true)
 		query = query.Where("id IN (SELECT contact_id FROM contact_vault_user WHERE user_id = ? AND is_favorite = ?)", userID, true)
+	case "needs_verification":
+		query = query.Where("listed = ?", true)
+		query = query.Where("needs_verification = ?", true)
 	default: // "active" or empty
 		query = query.Where("listed = ?", true)
 	}
@@ -474,6 +486,7 @@ func toContactResponse(c *models.Contact, isFavorite bool) dto.ContactResponse {
 		ShowQuickFacts: c.ShowQuickFacts,
 		IsArchived:     !c.Listed,
 		IsFavorite:     isFavorite,
+		NeedsVerification: c.NeedsVerification,
 		CreatedAt:      c.CreatedAt,
 		UpdatedAt:      c.UpdatedAt,
 	}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -509,7 +509,12 @@
       "filter_active": "Active",
       "filter_archived": "Archived",
       "filter_all": "All",
-      "filter_favorites": "Favorites"
+      "filter_favorites": "Favorites",
+      "filter_needs_verification": "Needs verification"
+    },
+    "needs_verification": {
+      "badge": "To verify",
+      "field_label": "Needs verification (flag for later review)"
     },
     "create": {
       "title": "Add a contact",

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -429,7 +429,12 @@
             "filter_active": "Activos",
             "filter_archived": "Archivados",
             "filter_all": "Todos",
-            "filter_favorites": "Favoritos"
+            "filter_favorites": "Favoritos",
+            "filter_needs_verification": "Por verificar"
+        },
+        "needs_verification": {
+            "badge": "Por verificar",
+            "field_label": "Necesita verificación (revisar más tarde)"
         },
         "create": {
             "title": "Añadir un contacto",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -509,7 +509,12 @@
       "filter_active": "活跃",
       "filter_archived": "已归档",
       "filter_all": "全部",
-      "filter_favorites": "收藏"
+      "filter_favorites": "收藏",
+      "filter_needs_verification": "待核实"
+    },
+    "needs_verification": {
+      "badge": "待核实",
+      "field_label": "标记为待核实（稍后再确认）"
     },
     "create": {
       "title": "添加联系人",

--- a/web/src/pages/contact/ContactCreate.tsx
+++ b/web/src/pages/contact/ContactCreate.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Card, Form, Input, Button, Typography, App, theme, Select } from "antd";
+import { Card, Form, Input, Button, Typography, App, theme, Select, Checkbox } from "antd";
 import { ArrowLeftOutlined, UserOutlined } from "@ant-design/icons";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api";
@@ -150,6 +150,10 @@ export default function ContactCreate() {
               <GenderPronounSelect entity="pronouns" vaultId={vaultId} placeholder={t("contact.form.select_pronoun")} />
             </Form.Item>
           </div>
+
+          <Form.Item name="needs_verification" valuePropName="checked" style={{ marginBottom: 8 }}>
+            <Checkbox>{t("contact.needs_verification.field_label")}</Checkbox>
+          </Form.Item>
 
           <Form.Item style={{ marginBottom: 0, marginTop: 8, textAlign: "right" }}>
             <Button

--- a/web/src/pages/contact/ContactDetail.tsx
+++ b/web/src/pages/contact/ContactDetail.tsx
@@ -19,6 +19,7 @@ import {
   Upload,
   theme,
   Dropdown,
+  Checkbox,
 } from "antd";
 import {
   EditOutlined,
@@ -306,6 +307,11 @@ export default function ContactDetail() {
         ) : (
           <Tag color="green" style={{ margin: 0 }}>{t("common.active")}</Tag>
         )}
+        {contact.needs_verification && (
+          <Tag color="warning" style={{ margin: 0 }}>
+            {t("contact.needs_verification.badge")}
+          </Tag>
+        )}
         <Text type="secondary" style={{ fontSize: 12 }}>
           {t("common.created")} {formatDate(contact.created_at, dateFormats)}
           {" · "}
@@ -546,6 +552,7 @@ export default function ContactDetail() {
                 maiden_name: contact.maiden_name,
                 gender_id: contact.gender_id,
                 pronoun_id: contact.pronoun_id,
+                needs_verification: contact.needs_verification,
               });
               setIsEditModalOpen(true);
             }}
@@ -725,6 +732,9 @@ export default function ContactDetail() {
               <GenderPronounSelect entity="pronouns" vaultId={vaultId} placeholder={t("contact.form.select_pronoun")} />
             </Form.Item>
           </div>
+          <Form.Item name="needs_verification" valuePropName="checked" style={{ marginBottom: 16 }}>
+            <Checkbox>{t("contact.needs_verification.field_label")}</Checkbox>
+          </Form.Item>
           <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
             <Button onClick={() => setIsEditModalOpen(false)}>
               {t("common.cancel")}

--- a/web/src/pages/contact/ContactList.tsx
+++ b/web/src/pages/contact/ContactList.tsx
@@ -148,6 +148,11 @@ export default function ContactList() {
             {record.is_favorite && (
               <StarFilled style={{ color: token.colorWarning, fontSize: 13 }} />
             )}
+            {record.needs_verification && (
+              <Tag color="warning" style={{ marginInlineEnd: 0 }}>
+                {t("contact.needs_verification.badge")}
+              </Tag>
+            )}
           </div>
         ),
       sorter: (a, b) => (a.first_name ?? '').localeCompare(b.first_name ?? ''),
@@ -387,6 +392,7 @@ export default function ContactList() {
         >
             <Option value="active">{t("contact.list.filter_active")}</Option>
             <Option value="favorites">{t("contact.list.filter_favorites")}</Option>
+            <Option value="needs_verification">{t("contact.list.filter_needs_verification")}</Option>
             <Option value="archived">{t("contact.list.filter_archived")}</Option>
             <Option value="all">{t("contact.list.filter_all")}</Option>
         </Select>


### PR DESCRIPTION
## Summary
- Adds a single boolean `needs_verification` on contacts so a person can flag an entry as "to double-check later." Useful for quick-capture during in-person meetings and for contacts created by an automated agent via the API.
- Default is `false` (verified). Callers opt in by sending `needs_verification: true` on create/update.

## Changes
- **Model:** new bool column with index for list filtering.
- **DTOs:** added to create/update/response.
- **Service:** respects the field on create/update; new `needs_verification` value for the existing `filter` query param on the list + list-by-label endpoints.
- **Frontend:** yellow "To verify" tag next to the contact's name on the detail page and contact list rows; checkbox in the create form and edit modal; filter option on the list (en/zh/es).

## Closes
naiba/bonds#119 — per your suggestion, default is verified and the user opts in.

## Test plan
- [x] Backend: `go build ./...` and `go test ./internal/services/ ./internal/handlers/` pass.
- [x] Frontend: `tsc --noEmit` passes.
- [ ] Manual: create a contact via UI with the checkbox ticked → badge appears on detail and list; toggle off via edit modal → badge disappears; list filter "Needs verification" returns only flagged contacts.
- [ ] Manual: create a contact via PAT/API with `needs_verification: true` → badge appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)