### PR TITLE
fix: set position and deduplicate columns in generic entity Create

### DIFF
--- a/server/internal/services/personalize.go
+++ b/server/internal/services/personalize.go
@@ -22,9 +22,10 @@ func NewPersonalizeService(db *gorm.DB) *PersonalizeService {
 }
 
 type entityConfig struct {
-	table    string
-	hasLabel bool
-	hasName  bool
+	table       string
+	hasLabel    bool
+	hasName     bool
+	hasPosition bool
 }
 
 var entityConfigs = map[string]entityConfig{
@@ -38,8 +39,8 @@ var entityConfigs = map[string]entityConfig{
 	"religions":          {table: "religions", hasName: true},
 	"gift-occasions":     {table: "gift_occasions", hasLabel: true},
 	"gift-states":        {table: "gift_states", hasLabel: true},
-	"group-types":        {table: "group_types", hasLabel: true},
-	"post-templates":     {table: "post_templates", hasLabel: true},
+	"group-types":        {table: "group_types", hasLabel: true, hasPosition: true},
+	"post-templates":     {table: "post_templates", hasLabel: true, hasPosition: true},
 	"relationship-types": {table: "relationship_group_types", hasName: true},
 	"templates":          {table: "templates", hasName: true},
 	"modules":            {table: "modules", hasName: true},
@@ -105,10 +106,32 @@ func (s *PersonalizeService) Create(accountID, entity string, req dto.Personaliz
 		val = req.Name
 	}
 
+	cols := fmt.Sprintf("account_id, %s", labelCol)
+	placeholders := "?, ?"
+	args := []interface{}{accountID, val}
+
+	if labelCol != nameCol {
+		cols += ", " + nameCol
+		placeholders += ", ?"
+		args = append(args, val)
+	}
+
+	if cfg.hasPosition {
+		var maxPos int
+		s.db.Raw(fmt.Sprintf("SELECT COALESCE(MAX(position), -1) FROM %s WHERE account_id = ?", cfg.table), accountID).Scan(&maxPos)
+		cols += ", position"
+		placeholders += ", ?"
+		args = append(args, maxPos+1)
+	}
+
 	now := time.Now()
+	cols += ", created_at, updated_at"
+	placeholders += ", ?, ?"
+	args = append(args, now, now)
+
 	result := s.db.Exec(
-		fmt.Sprintf("INSERT INTO %s (account_id, %s, %s, created_at, updated_at) VALUES (?, ?, ?, ?, ?)", cfg.table, labelCol, nameCol),
-		accountID, val, val, now, now,
+		fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", cfg.table, cols, placeholders),
+		args...,
 	)
 	if result.Error != nil {
 		return nil, result.Error

--- a/server/internal/services/personalize_create_update_test.go
+++ b/server/internal/services/personalize_create_update_test.go
@@ -21,6 +21,33 @@ func TestPersonalizeCreate_WorksOnSQLite(t *testing.T) {
 	}
 }
 
+func TestPersonalizeCreate_LabelOnlyPositionEntities(t *testing.T) {
+	svc, accountID := setupPersonalizeTest(t)
+
+	cases := []struct {
+		entity string
+		label  string
+	}{
+		{entity: "group-types", label: "Custom group type"},
+		{entity: "post-templates", label: "Custom post template"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.entity, func(t *testing.T) {
+			resp, err := svc.Create(accountID, tc.entity, dto.PersonalizeEntityRequest{Label: tc.label})
+			if err != nil {
+				t.Fatalf("Create(%s) failed: %v", tc.entity, err)
+			}
+			if resp.Label != tc.label {
+				t.Fatalf("label = %q, want %q", resp.Label, tc.label)
+			}
+			if resp.Name != tc.label {
+				t.Fatalf("name = %q, want %q", resp.Name, tc.label)
+			}
+		})
+	}
+}
+
 func TestPersonalizeUpdate_WorksOnSQLite(t *testing.T) {
 	svc, accountID := setupPersonalizeTest(t)
 


### PR DESCRIPTION
## Problem

On the `/settings/personalize` page, clicking **Add** under "Group Types" or
"Post Templates" always fails with the error **"Failed to create entity"**.

## Root Cause

Two bugs in `server/internal/services/personalize.go` `Create()`:

**1. Missing `position` value**
`group_types.position` and `post_templates.position` are `NOT NULL`, but the
generic INSERT never supplied a value, causing a DB constraint failure.

**2. Duplicate column in INSERT**
For entities with `hasLabel:true` and no `hasName`, both `getLabelCol()` and
`getNameCol()` return `"label"`, producing invalid SQL:

```sql
INSERT INTO group_types (account_id, label, label, created_at, updated_at)
VALUES (?, ?, ?, ?, ?)
```

## Fix

- Added `hasPosition bool` to `entityConfig`; marked `group-types` and
  `post-templates` with `hasPosition: true`.
- `Create` now builds its column list dynamically: skips the duplicate name
  column when it equals the label column, and inserts `MAX(position)+1` when
  `hasPosition` is set (same pattern already used by `createTaskStatus`).

## Affected entities

| Entity key      | Table           | Issues fixed              |
|-----------------|-----------------|---------------------------|
| `group-types`   | `group_types`   | duplicate column + position |
| `post-templates`| `post_templates`| duplicate column + position |

Other label-only entities (`call-reasons`, `gift-occasions`, `gift-states`) had
the duplicate-column bug but their `position` column is nullable, so only the
column deduplication fix applies to them.

## Testing

1. Go to **Settings → Personalize**.
2. Under **Group Types**, enter a name and click **Add**.
3. The entry should be created successfully and appear in the list.
4. Repeat for **Post Templates**.