### PR TITLE
fix(monica-import): gender silently dropped when Monica uses custom or non-English names

### DIFF
--- a/server/internal/services/monica_import.go
+++ b/server/internal/services/monica_import.go
@@ -210,7 +210,7 @@ func (s *MonicaImportService) Import(vaultID, userID string, data []byte) (*dto.
 
 func (s *MonicaImportService) importContact(
 	tx *gorm.DB, mc *MonicaContact, vaultID, accountID, userID string,
-	genderByUUID map[string]string, resp *dto.MonicaImportResponse,
+	genderByUUID map[string]MonicaGenderRef, resp *dto.MonicaImportResponse,
 ) (string, bool, error) {
 	var existingContact models.Contact
 	if err := tx.Where("vault_id = ? AND distant_uuid = ?", vaultID, mc.UUID).First(&existingContact).Error; err == nil {
@@ -220,10 +220,17 @@ func (s *MonicaImportService) importContact(
 
 	var genderID *uint
 	if mc.Properties.Gender != "" {
-		if genderName, ok := genderByUUID[mc.Properties.Gender]; ok {
+		if ref, ok := genderByUUID[mc.Properties.Gender]; ok {
 			var gender models.Gender
-			if err := tx.Where("account_id = ? AND name = ?", accountID, genderName).First(&gender).Error; err == nil {
+			// Try exact name match first (works when Monica and Bonds use
+			// the same locale), then fall back to the translation key which
+			// is locale-independent (M/F/O → seed.genders.*).
+			if tx.Where("account_id = ? AND name = ?", accountID, ref.Properties.Name).First(&gender).Error == nil {
 				genderID = &gender.ID
+			} else if key, ok := monicaTypeToKey[ref.Properties.Type]; ok {
+				if tx.Where("account_id = ? AND name_translation_key = ?", accountID, key).First(&gender).Error == nil {
+					genderID = &gender.ID
+				}
 			}
 		}
 	}
@@ -926,12 +933,20 @@ func monicaRelationshipNameCandidates(monicaType string) []string {
 	return candidates
 }
 
-func buildGenderMap(refs []MonicaGenderRef) map[string]string {
-	m := make(map[string]string, len(refs))
+func buildGenderMap(refs []MonicaGenderRef) map[string]MonicaGenderRef {
+	m := make(map[string]MonicaGenderRef, len(refs))
 	for _, r := range refs {
-		m[r.UUID] = r.Properties.Name
+		m[r.UUID] = r
 	}
 	return m
+}
+
+// monicaTypeToKey maps Monica's canonical gender type codes to the Bonds
+// seeded gender translation keys, used as a locale-independent fallback.
+var monicaTypeToKey = map[string]string{
+	"M": "seed.genders.male",
+	"F": "seed.genders.female",
+	"O": "seed.genders.other",
 }
 
 func buildFieldTypeMap(refs []MonicaContactFieldTypeRef) map[string]MonicaContactFieldTypeRef {
@@ -1190,6 +1205,7 @@ type MonicaGenderRef struct {
 	UUID       string `json:"uuid"`
 	Properties struct {
 		Name string `json:"name"`
+		Type string `json:"type"`
 	} `json:"properties"`
 }
 

--- a/server/internal/services/monica_import_test.go
+++ b/server/internal/services/monica_import_test.go
@@ -269,6 +269,10 @@ func TestMonicaImport_RealAnonymizedExport(t *testing.T) {
 }
 
 func setupMonicaImportTest(t *testing.T) (*MonicaImportService, string, string, string) {
+	return setupMonicaImportTestWithLocale(t, "en")
+}
+
+func setupMonicaImportTestWithLocale(t *testing.T, locale string) (*MonicaImportService, string, string, string) {
 	t.Helper()
 	db := testutil.SetupTestDB(t)
 	cfg := testutil.TestJWTConfig()
@@ -280,12 +284,12 @@ func setupMonicaImportTest(t *testing.T) (*MonicaImportService, string, string, 
 		LastName:  "User",
 		Email:     "monica-test@example.com",
 		Password:  "password123",
-	}, "en")
+	}, locale)
 	if err != nil {
 		t.Fatalf("Register failed: %v", err)
 	}
 
-	vault, err := vaultSvc.CreateVault(resp.User.AccountID, resp.User.ID, dto.CreateVaultRequest{Name: "Test Vault"}, "en")
+	vault, err := vaultSvc.CreateVault(resp.User.AccountID, resp.User.ID, dto.CreateVaultRequest{Name: "Test Vault"}, locale)
 	if err != nil {
 		t.Fatalf("CreateVault failed: %v", err)
 	}
@@ -362,6 +366,54 @@ func TestMonicaImportContacts_Gender(t *testing.T) {
 	}
 	if gender.Name == nil || *gender.Name != "Male" {
 		t.Errorf("expected gender name=Male, got %v", gender.Name)
+	}
+}
+
+func TestMonicaImportContacts_GenderFallsBackToType(t *testing.T) {
+	svc, vaultID, userID, _ := setupMonicaImportTestWithLocale(t, "zh")
+
+	exportJSON := `{
+		"version": "1.0-preview.1",
+		"account": {
+			"uuid": "test-account",
+			"data": [
+				{"count": 1, "type": "contacts", "values": [
+					{
+						"uuid": "contact-jane",
+						"properties": {"first_name": "Jane", "gender": "gender-f"},
+						"data": []
+					}
+				]}
+			],
+			"instance": {
+				"genders": [
+					{
+						"uuid": "gender-f",
+						"properties": {"name": "Item 50", "type": "F"}
+					}
+				]
+			}
+		}
+	}`
+
+	if _, err := svc.Import(vaultID, userID, []byte(exportJSON)); err != nil {
+		t.Fatalf("Import failed: %v", err)
+	}
+
+	var jane models.Contact
+	if err := svc.DB.Where("vault_id = ? AND first_name = ?", vaultID, "Jane").First(&jane).Error; err != nil {
+		t.Fatalf("Jane not found: %v", err)
+	}
+	if jane.GenderID == nil {
+		t.Fatal("expected Jane.GenderID to be set")
+	}
+
+	var gender models.Gender
+	if err := svc.DB.First(&gender, *jane.GenderID).Error; err != nil {
+		t.Fatalf("Gender not found: %v", err)
+	}
+	if gender.NameTranslationKey == nil || *gender.NameTranslationKey != "seed.genders.female" {
+		t.Errorf("expected gender name translation key seed.genders.female, got %v", gender.NameTranslationKey)
 	}
 }
 


### PR DESCRIPTION
## Problem

When importing contacts from a Monica JSON export, the gender field is silently
dropped on every contact. Contacts are created successfully but with no gender.

## Root Cause

Monica exports genders as UUIDs in contact properties, with a lookup table in
`instance.genders` that maps each UUID to `{ name: "Item 50", type: "F" }`.

Two bugs in `monica_import.go`:

**1. `Type` field not captured**
`MonicaGenderRef.Properties` only decoded `name`, discarding the canonical
`type` code (`"M"` / `"F"` / `"O"`).

**2. Name-based lookup always fails**
The import queried `WHERE name = "Item 50"` against the Bonds genders table,
which only contains seeded values. Even using the type code as a fallback
failed for non-English accounts: genders are seeded in the account's locale
(`i18n.T(locale, key)`), so a French account has `"Homme"` / `"Femme"` /
`"Autre"` — not `"Male"` / `"Female"` / `"Other"`.

No error was logged; `genderID` was silently left as `nil`.

## Fix

- Add `Type string \`json:"type"\`` to `MonicaGenderRef.Properties`.
- Change `buildGenderMap` to return `map[string]MonicaGenderRef` (full ref).
- In `importContact`, try exact name match first (works when Monica and Bonds
  share a locale), then fall back to `name_translation_key` lookup
  (`"seed.genders.male"` etc.) — locale-independent, always present on seeded
  genders.

## Testing

1. Export contacts from a Monica instance.
2. In Bonds, create a vault and go to **Vault Settings → Import**.
3. Import the Monica JSON file.
4. Open an imported contact — the gender field should now be populated.

Works regardless of the Bonds account locale.