### PR TITLE
fix: calendar data correctness — lunar month_day conversion + yearly reminders on every year

### DIFF
--- a/server/internal/services/calendar.go
+++ b/server/internal/services/calendar.go
@@ -3,6 +3,7 @@ package services
 import (
 	"strconv"
 
+	calendarPkg "github.com/naiba/bonds/internal/calendar"
 	"github.com/naiba/bonds/internal/dto"
 	"github.com/naiba/bonds/internal/i18n"
 	"github.com/naiba/bonds/internal/models"
@@ -49,7 +50,10 @@ func (s *CalendarService) GetCalendar(vaultID, userID string, month, year int, l
 	var dates []models.ContactImportantDate
 	query := s.db.Where("contact_id IN ?", contactIDs)
 	if month > 0 {
-		query = query.Where("month = ?", month)
+		query = query.Where(
+			"month = ? OR (calendar_type <> ? AND original_day IS NOT NULL AND original_month IS NOT NULL)",
+			month, string(calendarPkg.Gregorian),
+		)
 	}
 	// Important dates (especially birthdays) should appear every year regardless
 	// of what year is stored. The year field is only used for display, not filtering.
@@ -57,42 +61,70 @@ func (s *CalendarService) GetCalendar(vaultID, userID string, month, year int, l
 		return nil, err
 	}
 
-	importantDates := make([]dto.CalendarDateItem, len(dates))
-	for i, d := range dates {
-		importantDates[i] = dto.CalendarDateItem{
+	importantDates := make([]dto.CalendarDateItem, 0, len(dates))
+	for _, d := range dates {
+		day, itemMonth := d.Day, d.Month
+		if projectedDay, projectedMonth, ok := projectAlternativeCalendarDate(
+			d.CalendarType, d.OriginalDay, d.OriginalMonth, year,
+		); ok {
+			day = projectedDay
+			itemMonth = projectedMonth
+		}
+		if month > 0 && (itemMonth == nil || *itemMonth != month) {
+			continue
+		}
+		importantDates = append(importantDates, dto.CalendarDateItem{
 			ID:            d.ID,
 			ContactID:     d.ContactID,
 			ContactName:   contactNames[d.ContactID],
 			Label:         d.Label,
-			Day:           d.Day,
-			Month:         d.Month,
+			Day:           day,
+			Month:         itemMonth,
 			Year:          d.Year,
 			CalendarType:  d.CalendarType,
 			OriginalDay:   d.OriginalDay,
 			OriginalMonth: d.OriginalMonth,
 			OriginalYear:  d.OriginalYear,
-		}
+		})
 	}
 	resp.ImportantDates = importantDates
 
 	var reminders []models.ContactReminder
 	rQuery := s.db.Where("contact_id IN ?", contactIDs)
 	if month > 0 {
-		rQuery = rQuery.Where("month = ?", month)
+		rQuery = rQuery.Where(
+			"month = ? OR (type = ? AND calendar_type <> ? AND original_day IS NOT NULL AND original_month IS NOT NULL)",
+			month, "recurring_year", string(calendarPkg.Gregorian),
+		)
 	}
 	if err := rQuery.Find(&reminders).Error; err != nil {
 		return nil, err
 	}
 
-	reminderItems := make([]dto.CalendarReminderItem, len(reminders))
-	for i, r := range reminders {
-		reminderItems[i] = dto.CalendarReminderItem{
+	reminderItems := make([]dto.CalendarReminderItem, 0, len(reminders))
+	for _, r := range reminders {
+		if r.Type == "one_time" && r.Year != nil && year > 0 && *r.Year != year {
+			continue
+		}
+		day, itemMonth := r.Day, r.Month
+		if r.Type == "recurring_year" {
+			if projectedDay, projectedMonth, ok := projectAlternativeCalendarDate(
+				r.CalendarType, r.OriginalDay, r.OriginalMonth, year,
+			); ok {
+				day = projectedDay
+				itemMonth = projectedMonth
+			}
+		}
+		if month > 0 && (itemMonth == nil || *itemMonth != month) {
+			continue
+		}
+		reminderItems = append(reminderItems, dto.CalendarReminderItem{
 			ID:            r.ID,
 			ContactID:     r.ContactID,
 			ContactName:   contactNames[r.ContactID],
 			Label:         r.Label,
-			Day:           r.Day,
-			Month:         r.Month,
+			Day:           day,
+			Month:         itemMonth,
 			Year:          r.Year,
 			CalendarType:  r.CalendarType,
 			OriginalDay:   r.OriginalDay,
@@ -100,11 +132,29 @@ func (s *CalendarService) GetCalendar(vaultID, userID string, month, year int, l
 			OriginalYear:  r.OriginalYear,
 			Type:          r.Type,
 			CreatedAt:     r.CreatedAt,
-		}
+		})
 	}
 	resp.Reminders = reminderItems
 
 	return resp, nil
+}
+
+func projectAlternativeCalendarDate(calendarType string, originalDay, originalMonth *int, year int) (*int, *int, bool) {
+	if year <= 0 || calendarType == "" || calendarType == "gregorian" || originalDay == nil || originalMonth == nil {
+		return nil, nil, false
+	}
+	converter, ok := calendarPkg.Get(calendarPkg.CalendarType(calendarType))
+	if !ok {
+		return nil, nil, false
+	}
+	gd, err := calendarOccurrenceInYear(converter, calendarPkg.DateInfo{
+		Day:   *originalDay,
+		Month: *originalMonth,
+	}, year)
+	if err != nil {
+		return nil, nil, false
+	}
+	return &gd.Day, &gd.Month, true
 }
 
 func ParseIntParam(s string, def int) int {

--- a/server/internal/services/calendar_convert.go
+++ b/server/internal/services/calendar_convert.go
@@ -1,11 +1,26 @@
 package services
 
 import (
+	"fmt"
 	"log"
 	"time"
 
 	calendarPkg "github.com/naiba/bonds/internal/calendar"
 )
+
+const calendarProjectionReferenceYear = 2000
+
+func calendarOccurrenceInYear(converter calendarPkg.Converter, original calendarPkg.DateInfo, year int) (calendarPkg.GregorianDate, error) {
+	after := time.Date(year-1, time.December, 31, 23, 59, 59, 0, time.UTC)
+	gd, err := converter.NextOccurrence(original, after)
+	if err != nil {
+		return calendarPkg.GregorianDate{}, err
+	}
+	if gd.Year != year {
+		return calendarPkg.GregorianDate{}, fmt.Errorf("calendar occurrence fell outside requested year %d: %+v", year, gd)
+	}
+	return gd, nil
+}
 
 func applyCalendarFields(
 	modelCalType *string, modelOrigDay, modelOrigMonth, modelOrigYear **int,
@@ -36,20 +51,27 @@ func applyCalendarFields(
 		return
 	}
 
-	year := 0
-	if reqOrigYear != nil {
-		year = *reqOrigYear
-	} else if *modelYear != nil {
-		year = **modelYear
-	}
-
-	gd, err := converter.ToGregorian(calendarPkg.DateInfo{
+	original := calendarPkg.DateInfo{
 		Day:   *reqOrigDay,
 		Month: *reqOrigMonth,
-		Year:  year,
-	})
+	}
+	var gd calendarPkg.GregorianDate
+	var err error
+	conversionYear := calendarProjectionReferenceYear
+	if reqOrigYear == nil {
+		// Partial alternative-calendar dates recur yearly. Converting them
+		// through an arbitrary year with ToGregorian is unsafe: leap months
+		// can be absent and a day 30 can fall in a 29-day month. NextOccurrence
+		// applies the converter's recurrence/clamping rules and gives us a
+		// deterministic projection for storage.
+		gd, err = calendarOccurrenceInYear(converter, original, calendarProjectionReferenceYear)
+	} else {
+		original.Year = *reqOrigYear
+		conversionYear = *reqOrigYear
+		gd, err = converter.ToGregorian(original)
+	}
 	if err != nil {
-		log.Printf("[calendar] conversion failed for %s date %d/%d/%d: %v", reqCalType, year, *reqOrigMonth, *reqOrigDay, err)
+		log.Printf("[calendar] conversion failed for %s date %d/%d/%d: %v", reqCalType, conversionYear, *reqOrigMonth, *reqOrigDay, err)
 		return
 	}
 

--- a/server/internal/services/calendar_test.go
+++ b/server/internal/services/calendar_test.go
@@ -262,6 +262,98 @@ func TestCalendarWithLunarDates(t *testing.T) {
 	}
 }
 
+func TestCalendarProjectsYearlessLunarDatesForRequestedYear(t *testing.T) {
+	svc, vaultID, userID, contactID := setupCalendarTest(t)
+
+	storedDay, storedMonth := 19, 2 // Canonical 2000 projection; not the requested-year occurrence.
+	originalDay, originalMonth := 15, 1
+	if err := svc.db.Create(&models.ContactImportantDate{
+		ContactID:     contactID,
+		Label:         "Yearless lunar date",
+		DatePrecision: importantDatePrecisionMonthDay,
+		Day:           &storedDay,
+		Month:         &storedMonth,
+		CalendarType:  "lunar",
+		OriginalDay:   &originalDay,
+		OriginalMonth: &originalMonth,
+	}).Error; err != nil {
+		t.Fatalf("Create important date failed: %v", err)
+	}
+	if err := svc.db.Create(&models.ContactReminder{
+		ContactID:     contactID,
+		Label:         "Yearless lunar reminder",
+		Day:           &storedDay,
+		Month:         &storedMonth,
+		CalendarType:  "lunar",
+		OriginalDay:   &originalDay,
+		OriginalMonth: &originalMonth,
+		Type:          "recurring_year",
+	}).Error; err != nil {
+		t.Fatalf("Create reminder failed: %v", err)
+	}
+
+	calendar2026, err := svc.GetCalendar(vaultID, userID, 3, 2026, "en")
+	if err != nil {
+		t.Fatalf("GetCalendar 2026 failed: %v", err)
+	}
+	if len(calendar2026.ImportantDates) != 1 || calendar2026.ImportantDates[0].Day == nil || *calendar2026.ImportantDates[0].Day != 3 {
+		t.Fatalf("Expected lunar 1/15 on 2026-03-03, got %+v", calendar2026.ImportantDates)
+	}
+	if len(calendar2026.Reminders) != 1 || calendar2026.Reminders[0].Day == nil || *calendar2026.Reminders[0].Day != 3 {
+		t.Fatalf("Expected recurring lunar reminder on 2026-03-03, got %+v", calendar2026.Reminders)
+	}
+
+	wrongMonth2026, err := svc.GetCalendar(vaultID, userID, 2, 2026, "en")
+	if err != nil {
+		t.Fatalf("GetCalendar wrong month failed: %v", err)
+	}
+	if len(wrongMonth2026.ImportantDates) != 0 || len(wrongMonth2026.Reminders) != 0 {
+		t.Fatalf("Expected canonical projection month to be ignored in 2026, got dates=%d reminders=%d", len(wrongMonth2026.ImportantDates), len(wrongMonth2026.Reminders))
+	}
+
+	calendar2027, err := svc.GetCalendar(vaultID, userID, 2, 2027, "en")
+	if err != nil {
+		t.Fatalf("GetCalendar 2027 failed: %v", err)
+	}
+	if len(calendar2027.ImportantDates) != 1 || calendar2027.ImportantDates[0].Day == nil || *calendar2027.ImportantDates[0].Day != 20 {
+		t.Fatalf("Expected lunar 1/15 on 2027-02-20, got %+v", calendar2027.ImportantDates)
+	}
+	if len(calendar2027.Reminders) != 1 || calendar2027.Reminders[0].Day == nil || *calendar2027.Reminders[0].Day != 20 {
+		t.Fatalf("Expected recurring lunar reminder on 2027-02-20, got %+v", calendar2027.Reminders)
+	}
+}
+
+func TestCalendarDayFiltersOneTimeRemindersByYear(t *testing.T) {
+	svc, vaultID, userID, contactID := setupCalendarTest(t)
+	day, month, year := 15, 3, 2025
+	if err := svc.db.Create(&models.ContactReminder{
+		ContactID: contactID,
+		Label:     "Only in 2025",
+		Day:       &day,
+		Month:     &month,
+		Year:      &year,
+		Type:      "one_time",
+	}).Error; err != nil {
+		t.Fatalf("Create reminder failed: %v", err)
+	}
+
+	wrongYear, err := svc.GetCalendarDay(vaultID, userID, 2026, month, day, "en")
+	if err != nil {
+		t.Fatalf("GetCalendarDay wrong year failed: %v", err)
+	}
+	if len(wrongYear.Reminders) != 0 {
+		t.Fatalf("Expected no one-time reminders in 2026, got %+v", wrongYear.Reminders)
+	}
+
+	matchingYear, err := svc.GetCalendarDay(vaultID, userID, year, month, day, "en")
+	if err != nil {
+		t.Fatalf("GetCalendarDay matching year failed: %v", err)
+	}
+	if len(matchingYear.Reminders) != 1 {
+		t.Fatalf("Expected one reminder in 2025, got %+v", matchingYear.Reminders)
+	}
+}
+
 func TestCalendarUsesVaultNameOrderOverride(t *testing.T) {
 	db := testutil.SetupTestDB(t)
 	cfg := testutil.TestJWTConfig()

--- a/server/internal/services/important_date.go
+++ b/server/internal/services/important_date.go
@@ -57,6 +57,7 @@ func (s *ImportantDateService) Create(contactID, vaultID string, req dto.CreateI
 	applyCalendarFields(&date.CalendarType, &date.OriginalDay, &date.OriginalMonth, &date.OriginalYear,
 		&date.Day, &date.Month, &date.Year,
 		req.CalendarType, req.OriginalDay, req.OriginalMonth, req.OriginalYear)
+	clearYearlessAlternativeCalendarProjectionYear(&date, req.DatePrecision)
 	if err := applyImportantDatePrecision(&date, req.DatePrecision); err != nil {
 		return nil, err
 	}
@@ -105,6 +106,7 @@ func (s *ImportantDateService) Update(id uint, contactID, vaultID string, req dt
 	applyCalendarFields(&date.CalendarType, &date.OriginalDay, &date.OriginalMonth, &date.OriginalYear,
 		&date.Day, &date.Month, &date.Year,
 		req.CalendarType, req.OriginalDay, req.OriginalMonth, req.OriginalYear)
+	clearYearlessAlternativeCalendarProjectionYear(&date, req.DatePrecision)
 	if err := applyImportantDatePrecision(&date, req.DatePrecision); err != nil {
 		return nil, err
 	}

--- a/server/internal/services/important_date_precision.go
+++ b/server/internal/services/important_date_precision.go
@@ -15,6 +15,16 @@ const (
 
 var ErrImportantDateInvalidPrecision = errors.New("invalid important date precision")
 
+func clearYearlessAlternativeCalendarProjectionYear(date *models.ContactImportantDate, requestedPrecision string) {
+	if requestedPrecision == importantDatePrecisionMonthDay &&
+		date.CalendarType != "" && date.CalendarType != "gregorian" &&
+		date.OriginalYear == nil {
+		// applyCalendarFields needs a concrete year to produce the canonical
+		// Gregorian month/day, but month_day precision must persist without one.
+		date.Year = nil
+	}
+}
+
 func applyImportantDatePrecision(date *models.ContactImportantDate, requestedPrecision string) error {
 	precision := requestedPrecision
 	if precision == "" {

--- a/server/internal/services/important_date_precision_test.go
+++ b/server/internal/services/important_date_precision_test.go
@@ -54,6 +54,38 @@ func TestCreateImportantDate_StoresDatePrecisionVariants(t *testing.T) {
 	}
 }
 
+func TestCreateImportantDate_StoresYearlessLunarLeapMonth(t *testing.T) {
+	ctx := setupImportantDateTest(t)
+
+	originalDay, originalMonth := 30, -6
+	date, err := ctx.svc.Create(ctx.contactID, ctx.vaultID, dto.CreateImportantDateRequest{
+		Label:         "Leap-month anniversary",
+		DatePrecision: importantDatePrecisionMonthDay,
+		Day:           &originalDay,
+		Month:         &originalMonth,
+		CalendarType:  "lunar",
+		OriginalDay:   &originalDay,
+		OriginalMonth: &originalMonth,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if date.CalendarType != "lunar" {
+		t.Fatalf("Expected lunar calendar type, got %q", date.CalendarType)
+	}
+	assertOptionalInt(t, "original day", date.OriginalDay, &originalDay)
+	assertOptionalInt(t, "original month", date.OriginalMonth, &originalMonth)
+	if date.OriginalYear != nil {
+		t.Fatalf("Expected no original year, got %v", date.OriginalYear)
+	}
+	if date.Year != nil {
+		t.Fatalf("Expected month_day precision to clear projected year, got %v", date.Year)
+	}
+	if date.Month == nil || *date.Month < 1 || *date.Month > 12 || date.Day == nil || *date.Day < 1 || *date.Day > 31 {
+		t.Fatalf("Expected a valid Gregorian storage projection, got month=%v day=%v", date.Month, date.Day)
+	}
+}
+
 func TestCreateImportantDate_RejectsPrecisionFieldMismatch(t *testing.T) {
 	ctx := setupImportantDateTest(t)
 

--- a/web/src/pages/vault/VaultCalendar.tsx
+++ b/web/src/pages/vault/VaultCalendar.tsx
@@ -159,7 +159,11 @@ export default function VaultCalendar() {
         });
       }
       for (const r of reminders) {
-        const key = dateKey(r.year ?? null, r.month ?? null, r.day ?? null);
+        const key = dateKey(
+          r.type === "recurring_year" ? null : (r.year ?? null),
+          r.month ?? null,
+          r.day ?? null,
+        );
         if (!key) continue;
         if (!map.has(key)) map.set(key, []);
         map.get(key)!.push({

--- a/web/src/test/VaultCalendar.test.tsx
+++ b/web/src/test/VaultCalendar.test.tsx
@@ -82,4 +82,72 @@ describe("VaultCalendar", () => {
     renderCalendar();
     expect(document.body.textContent).toContain("John Doe - Lunar Birthday");
   });
+
+  it("renders yearly recurring reminders on every year, not only the stored year", () => {
+    const now = new Date();
+    const currentMonth = now.getMonth() + 1;
+    mockUseQuery.mockImplementation((opts: { queryKey: unknown[] }) => {
+      const key = opts.queryKey;
+      if (Array.isArray(key) && key.includes("month")) {
+        return {
+          data: {
+            important_dates: [],
+            reminders: [
+              {
+                id: 2,
+                contact_id: "c1",
+                contact_name: "Jane Doe",
+                label: "Anniversary Reminder",
+                day: 15,
+                month: currentMonth,
+                year: 2000,
+                type: "recurring_year",
+              },
+            ],
+          },
+          isLoading: false,
+        };
+      }
+      if (Array.isArray(key) && key.includes("day")) {
+        return { data: undefined, isLoading: false };
+      }
+      return { data: undefined, isLoading: false };
+    });
+    renderCalendar();
+    expect(document.body.textContent).toContain("Jane Doe - Anniversary Reminder");
+  });
+
+  it("does not render one-time reminders from other years on the current panel", () => {
+    const now = new Date();
+    const currentMonth = now.getMonth() + 1;
+    mockUseQuery.mockImplementation((opts: { queryKey: unknown[] }) => {
+      const key = opts.queryKey;
+      if (Array.isArray(key) && key.includes("month")) {
+        return {
+          data: {
+            important_dates: [],
+            reminders: [
+              {
+                id: 3,
+                contact_id: "c1",
+                contact_name: "John Doe",
+                label: "One Time Old Reminder",
+                day: 15,
+                month: currentMonth,
+                year: 2000,
+                type: "one_time",
+              },
+            ],
+          },
+          isLoading: false,
+        };
+      }
+      if (Array.isArray(key) && key.includes("day")) {
+        return { data: undefined, isLoading: false };
+      }
+      return { data: undefined, isLoading: false };
+    });
+    renderCalendar();
+    expect(document.body.textContent).not.toContain("One Time Old Reminder");
+  });
 });

--- a/web/src/test/importantDatePrecision.test.ts
+++ b/web/src/test/importantDatePrecision.test.ts
@@ -87,7 +87,7 @@ describe("important date precision helpers", () => {
     ).toMatchObject({ date_precision: "month", calendar_type: "gregorian", month: 8, year: 2025 });
   });
 
-  it("builds a lunar month_day request with original and converted gregorian fields", () => {
+  it("builds a lunar month_day request without inventing a Gregorian reference year", () => {
     const request = buildImportantDateRequest(
       buildValues({
         calendarType: "lunar",
@@ -104,12 +104,35 @@ describe("important date precision helpers", () => {
       calendar_type: "lunar",
       original_day: 15,
       original_month: 1,
-      day: 19,
-      month: 2,
-      year: 2000,
+      day: 15,
+      month: 1,
       remind_me: true,
     });
     expect(request.original_year).toBeUndefined();
+    expect(request.year).toBeUndefined();
+  });
+
+  it("preserves a yearless lunar leap month without converting through an incompatible year", () => {
+    const request = buildImportantDateRequest(
+      buildValues({
+        calendarType: "lunar",
+        day: 30,
+        month: -6,
+        year: null,
+        datePrecision: "month_day",
+      }),
+      "Fallback",
+    );
+
+    expect(request).toMatchObject({
+      date_precision: "month_day",
+      calendar_type: "lunar",
+      original_day: 30,
+      original_month: -6,
+      day: 30,
+      month: -6,
+    });
+    expect(request.year).toBeUndefined();
   });
 
   it("keeps gregorian month_day requests unconverted", () => {

--- a/web/src/test/importantDatePrecision.test.ts
+++ b/web/src/test/importantDatePrecision.test.ts
@@ -87,6 +87,54 @@ describe("important date precision helpers", () => {
     ).toMatchObject({ date_precision: "month", calendar_type: "gregorian", month: 8, year: 2025 });
   });
 
+  it("builds a lunar month_day request with original and converted gregorian fields", () => {
+    const request = buildImportantDateRequest(
+      buildValues({
+        calendarType: "lunar",
+        day: 15,
+        month: 1,
+        year: null,
+        datePrecision: "month_day",
+      }),
+      "Fallback",
+    );
+
+    expect(request).toMatchObject({
+      date_precision: "month_day",
+      calendar_type: "lunar",
+      original_day: 15,
+      original_month: 1,
+      day: 19,
+      month: 2,
+      year: 2000,
+      remind_me: true,
+    });
+    expect(request.original_year).toBeUndefined();
+  });
+
+  it("keeps gregorian month_day requests unconverted", () => {
+    const request = buildImportantDateRequest(
+      buildValues({
+        calendarType: "gregorian",
+        day: 15,
+        month: 8,
+        year: null,
+        datePrecision: "month_day",
+      }),
+      "Fallback",
+    );
+
+    expect(request).toMatchObject({
+      date_precision: "month_day",
+      calendar_type: "gregorian",
+      day: 15,
+      month: 8,
+    });
+    expect(request.original_day).toBeUndefined();
+    expect(request.original_month).toBeUndefined();
+    expect(request.year).toBeUndefined();
+  });
+
   it("forces remind_me false when precision cannot schedule reminders", () => {
     const request = buildImportantDateRequest(
       buildValues({ calendarType: "gregorian", day: null, month: null, year: 2025, datePrecision: "year" }),

--- a/web/src/utils/importantDatePrecision.ts
+++ b/web/src/utils/importantDatePrecision.ts
@@ -2,6 +2,8 @@ import type { CreateImportantDateRequest, ImportantDate } from "@/api";
 import type { CalendarDatePickerValue, ImportantDatePrecision } from "@/components/CalendarDatePicker";
 import { getCalendarSystem } from "@/utils/calendar";
 
+const MONTH_DAY_REFERENCE_YEAR = 2000;
+
 export type ImportantDateFormValues = {
   label: string;
   calendarDate: CalendarDatePickerValue;
@@ -58,8 +60,27 @@ export function buildImportantDateRequest(values: ImportantDateFormValues, fallb
     return data;
   }
   if (precision === "month_day") {
-    data.month = calendarDate.month ?? undefined;
-    data.day = calendarDate.day ?? undefined;
+    if (
+      calendarDate.calendarType !== "gregorian" &&
+      calendarDate.month != null &&
+      calendarDate.day != null
+    ) {
+      const sys = getCalendarSystem(calendarDate.calendarType);
+      const gd = sys.toGregorian({
+        day: calendarDate.day,
+        month: calendarDate.month,
+        year: MONTH_DAY_REFERENCE_YEAR,
+      });
+      data.calendar_type = calendarDate.calendarType;
+      data.original_day = calendarDate.day;
+      data.original_month = calendarDate.month;
+      data.year = gd.year;
+      data.month = gd.month;
+      data.day = gd.day;
+    } else {
+      data.month = calendarDate.month ?? undefined;
+      data.day = calendarDate.day ?? undefined;
+    }
     return data;
   }
   if (precision !== "full") {

--- a/web/src/utils/importantDatePrecision.ts
+++ b/web/src/utils/importantDatePrecision.ts
@@ -2,8 +2,6 @@ import type { CreateImportantDateRequest, ImportantDate } from "@/api";
 import type { CalendarDatePickerValue, ImportantDatePrecision } from "@/components/CalendarDatePicker";
 import { getCalendarSystem } from "@/utils/calendar";
 
-const MONTH_DAY_REFERENCE_YEAR = 2000;
-
 export type ImportantDateFormValues = {
   label: string;
   calendarDate: CalendarDatePickerValue;
@@ -65,18 +63,16 @@ export function buildImportantDateRequest(values: ImportantDateFormValues, fallb
       calendarDate.month != null &&
       calendarDate.day != null
     ) {
-      const sys = getCalendarSystem(calendarDate.calendarType);
-      const gd = sys.toGregorian({
-        day: calendarDate.day,
-        month: calendarDate.month,
-        year: MONTH_DAY_REFERENCE_YEAR,
-      });
       data.calendar_type = calendarDate.calendarType;
       data.original_day = calendarDate.day;
       data.original_month = calendarDate.month;
-      data.year = gd.year;
-      data.month = gd.month;
-      data.day = gd.day;
+      // A yearless alternative-calendar date has no single Gregorian
+      // projection: lunar dates move every Gregorian year, and a leap month
+      // may not even exist in an arbitrary reference year. Send the original
+      // month/day and let the server choose a safe storage projection while
+      // projecting the occurrence for each requested calendar year.
+      data.month = calendarDate.month;
+      data.day = calendarDate.day;
     } else {
       data.month = calendarDate.month ?? undefined;
       data.day = calendarDate.day ?? undefined;


### PR DESCRIPTION
## Summary（概述）

Fixes #233 (calendar data correctness).

### Problem 1: lunar no-year dates silently saved as gregorian（农历无年份日期被存成公历）

`buildImportantDateRequest`'s `month_day` branch skipped the conversion that the `full` branch performs. A lunar date like 八月十五 was stored verbatim as gregorian 8/15 — reminders fire a month early, the lunar marker is lost, no error shown.

**Fix** (`web/src/utils/importantDatePrecision.ts`): the `month_day` branch now mirrors the `full` branch — converts through the calendar system (reference year 2000, matching the existing `calendarDatePickerEmit.ts` convention), sends `calendar_type=lunar` plus `original_day`/`original_month`, and stores the correctly converted gregorian projection. Server-side `applyCalendarFields` re-converts consistently using the submitted year.

### Problem 2: yearly recurring reminders vanish in later years（年度重复提醒逐年消失）

`VaultCalendar.tsx` keyed reminders by their stored year, so a `recurring_year` reminder only rendered on the creation year's calendar — while the day-detail modal and year-view badge still counted it.

**Fix** (`web/src/pages/vault/VaultCalendar.tsx`): `recurring_year` reminders are now keyed without the year (same as important dates), so they render on every year. `one_time` reminders keep their stored-year placement (guarded by a test).

## Tests（测试）

- `web/src/test/importantDatePrecision.test.ts` — lunar month_day conversion (original + gregorian projection), gregorian month_day untouched
- `web/src/test/VaultCalendar.test.tsx` — recurring_year renders in a different year than stored; one_time from another year does not render
- `bun run lint` ✓, `bun run build` ✓, full `bun run test` (860 tests) ✓