### PR TITLE
fix: date picker clear/empty state and vault detail delete confirm + header wrap

### DIFF
--- a/web/src/components/CalendarAwareDatePicker.tsx
+++ b/web/src/components/CalendarAwareDatePicker.tsx
@@ -31,12 +31,15 @@ export default function CalendarAwareDatePicker({
   allowClear,
   style,
 }: CalendarAwareDatePickerProps) {
-  const pickerValue = useMemo<CalendarDatePickerValue>(() => {
+  const pickerValue = useMemo<CalendarDatePickerValue | undefined>(() => {
     if (!value) {
-      const now = dayjs();
-      return { calendarType: "gregorian", day: now.date(), month: now.month() + 1, year: now.year(), datePrecision: "full" };
+      return undefined;
     }
-    if (value.calendarType !== "gregorian" && value.originalDay != null && value.originalMonth != null) {
+    if (
+      value.calendarType !== "gregorian" &&
+      value.originalDay != null &&
+      value.originalMonth != null
+    ) {
       return {
         calendarType: value.calendarType,
         day: value.originalDay,
@@ -87,8 +90,10 @@ export default function CalendarAwareDatePicker({
     <CalendarDatePicker
       enableAlternativeCalendar
       value={pickerValue}
+      allowClear={allowClear}
       onChange={(next) => {
-        if (next.day == null || next.month == null) {
+        if (!next || next.day == null || next.month == null) {
+          onChange?.(null);
           return;
         }
 

--- a/web/src/components/CalendarDatePicker.tsx
+++ b/web/src/components/CalendarDatePicker.tsx
@@ -7,23 +7,32 @@ import CalendarDatePickerControls from "./CalendarDatePickerControls";
 import { createCalendarDatePickerHandlers } from "./calendarDatePickerHandlers";
 import { formatCalendarDatePickerPreview } from "./calendarDatePickerPreview";
 import { inferPrecisionFromValue } from "./calendarDatePickerValue";
-import type { CalendarDatePickerValue, ImportantDatePrecision } from "./calendarDatePickerValue";
+import type {
+  CalendarDatePickerValue,
+  ImportantDatePrecision,
+} from "./calendarDatePickerValue";
 
-export type { CalendarDatePickerValue, ImportantDatePrecision } from "./calendarDatePickerValue";
+export type {
+  CalendarDatePickerValue,
+  ImportantDatePrecision,
+} from "./calendarDatePickerValue";
 
 const { Text } = Typography;
 
 const NO_YEAR_VALUE = -1;
 interface CalendarDatePickerProps {
-  value?: CalendarDatePickerValue;
-  onChange?: (value: CalendarDatePickerValue) => void;
+  value?: CalendarDatePickerValue | null;
+  onChange?: (value: CalendarDatePickerValue | null) => void;
   enableAlternativeCalendar?: boolean;
   enableNoYear?: boolean;
   enableDatePrecision?: boolean;
   allowedDatePrecisions?: readonly ImportantDatePrecision[];
+  allowClear?: boolean;
 }
 
-function buildDayOptions(totalDays: number): Array<{ value: number; label: string }> {
+function buildDayOptions(
+  totalDays: number,
+): Array<{ value: number; label: string }> {
   const options = [];
   for (let day = 1; day <= totalDays; day += 1) {
     options.push({ value: day, label: String(day) });
@@ -36,7 +45,9 @@ function buildGregorianMonthOptions(): Array<{ value: number; label: string }> {
   for (let month = 1; month <= 12; month += 1) {
     options.push({
       value: month,
-      label: dayjs().month(month - 1).format("MMMM"),
+      label: dayjs()
+        .month(month - 1)
+        .format("MMMM"),
     });
   }
   return options;
@@ -49,20 +60,31 @@ export default function CalendarDatePicker({
   enableNoYear = false,
   enableDatePrecision = false,
   allowedDatePrecisions = ["full", "month", "year", "month_day"],
+  allowClear,
 }: CalendarDatePickerProps) {
   const { t } = useTranslation();
   const now = dayjs();
 
   const calendarType = value?.calendarType ?? "gregorian";
-  const inferredPrecision = inferPrecisionFromValue(value);
+  const inferredPrecision = inferPrecisionFromValue(value ?? undefined);
   const datePrecision = allowedDatePrecisions.includes(inferredPrecision)
     ? inferredPrecision
-    : allowedDatePrecisions[0] ?? "full";
+    : (allowedDatePrecisions[0] ?? "full");
   const usesPrecisionLayout = enableDatePrecision;
   const selectedYear = value?.year ?? now.year();
   const selectedMonth = value?.month ?? now.month() + 1;
   const selectedDay = value?.day ?? now.date();
   const displayYear = datePrecision === "month_day" ? null : selectedYear;
+  const controlYear =
+    value == null
+      ? undefined
+      : datePrecision === "month_day"
+        ? null
+        : (value.year ?? undefined);
+  const controlMonth = value?.month ?? undefined;
+  const controlDay = value?.day ?? undefined;
+  const hasCompleteSelection =
+    value?.day != null && value.month != null && value.year != null;
 
   const calendarSystem = getCalendarSystem(calendarType);
   const selectableMonths = calendarSystem.getMonths(selectedYear);
@@ -84,11 +106,11 @@ export default function CalendarDatePicker({
 
   const gregorianMonthOptions = buildGregorianMonthOptions();
   const gregorianDayOptions = (() => {
-    const referenceYear = datePrecision === "month_day"
-      ? 2000
-      : selectedYear;
+    const referenceYear = datePrecision === "month_day" ? 2000 : selectedYear;
     return buildDayOptions(
-      dayjs(`${referenceYear}-${String(selectedMonth).padStart(2, "0")}-01`).daysInMonth(),
+      dayjs(
+        `${referenceYear}-${String(selectedMonth).padStart(2, "0")}-01`,
+      ).daysInMonth(),
     );
   })();
 
@@ -103,15 +125,17 @@ export default function CalendarDatePicker({
     onChange,
   });
 
-  const previewText = formatCalendarDatePickerPreview({
-    calendarType,
-    datePrecision,
-    selectedDay,
-    selectedMonth,
-    selectedYear,
-    gregorianLabel: t("calendar.gregorian"),
-    lunarLabel: t("calendar.lunar"),
-  });
+  const previewText = hasCompleteSelection
+    ? formatCalendarDatePickerPreview({
+        calendarType,
+        datePrecision,
+        selectedDay,
+        selectedMonth,
+        selectedYear,
+        gregorianLabel: t("calendar.gregorian"),
+        lunarLabel: t("calendar.lunar"),
+      })
+    : "";
 
   const calendarTypeOptions = supportedCalendarTypes.map((type) => ({
     value: type,
@@ -124,12 +148,16 @@ export default function CalendarDatePicker({
       availablePrecisions={allowedDatePrecisions}
       usesPrecisionLayout={usesPrecisionLayout}
       datePrecision={datePrecision}
-      displayYear={displayYear}
-      selectedMonth={selectedMonth}
-      selectedDay={selectedDay}
+      displayYear={controlYear}
+      selectedMonth={controlMonth}
+      selectedDay={controlDay}
       yearOptions={yearOptions}
-      monthOptions={calendarType === "gregorian" ? gregorianMonthOptions : selectableMonths}
-      dayOptions={calendarType === "gregorian" ? gregorianDayOptions : selectableDays}
+      monthOptions={
+        calendarType === "gregorian" ? gregorianMonthOptions : selectableMonths
+      }
+      dayOptions={
+        calendarType === "gregorian" ? gregorianDayOptions : selectableDays
+      }
       noYearValue={NO_YEAR_VALUE}
       yearPlaceholder={t("calendar.year")}
       monthPlaceholder={t("calendar.month")}
@@ -159,9 +187,10 @@ export default function CalendarDatePicker({
     );
   };
 
-  const hasSelection = value?.day != null && value?.month != null;
-  const pickerValue = hasSelection
-    ? dayjs(`${selectedYear}-${String(selectedMonth).padStart(2, "0")}-${String(selectedDay).padStart(2, "0")}`)
+  const pickerValue = hasCompleteSelection
+    ? dayjs(
+        `${selectedYear}-${String(selectedMonth).padStart(2, "0")}-${String(selectedDay).padStart(2, "0")}`,
+      )
     : null;
 
   if (!enableAlternativeCalendar) {
@@ -173,6 +202,7 @@ export default function CalendarDatePicker({
       <DatePicker
         value={pickerValue}
         onChange={handleDatePickerChange}
+        allowClear={allowClear}
         style={{ width: "100%" }}
       />
     );
@@ -193,6 +223,7 @@ export default function CalendarDatePicker({
         <DatePicker
           value={pickerValue}
           onChange={handleDatePickerChange}
+          allowClear={allowClear}
           style={{ width: "100%" }}
         />
       ) : (
@@ -200,7 +231,10 @@ export default function CalendarDatePicker({
       )}
 
       {previewText && (
-        <Text type="secondary" style={{ fontSize: 12, marginTop: 4, display: "block" }}>
+        <Text
+          type="secondary"
+          style={{ fontSize: 12, marginTop: 4, display: "block" }}
+        >
           {previewText}
         </Text>
       )}

--- a/web/src/components/CalendarDatePicker.tsx
+++ b/web/src/components/CalendarDatePicker.tsx
@@ -149,6 +149,7 @@ export default function CalendarDatePicker({
 
   const handleDatePickerChange = (nextDate: Dayjs | null) => {
     if (!nextDate) {
+      handlers.handleClear();
       return;
     }
     handlers.handleGregorianChange(
@@ -158,6 +159,11 @@ export default function CalendarDatePicker({
     );
   };
 
+  const hasSelection = value?.day != null && value?.month != null;
+  const pickerValue = hasSelection
+    ? dayjs(`${selectedYear}-${String(selectedMonth).padStart(2, "0")}-${String(selectedDay).padStart(2, "0")}`)
+    : null;
+
   if (!enableAlternativeCalendar) {
     if (enableNoYear || enableDatePrecision) {
       return fieldControls;
@@ -165,7 +171,7 @@ export default function CalendarDatePicker({
 
     return (
       <DatePicker
-        value={dayjs(`${selectedYear}-${String(selectedMonth).padStart(2, "0")}-${String(selectedDay).padStart(2, "0")}`)}
+        value={pickerValue}
         onChange={handleDatePickerChange}
         style={{ width: "100%" }}
       />
@@ -185,7 +191,7 @@ export default function CalendarDatePicker({
 
       {calendarType === "gregorian" && !enableNoYear && !enableDatePrecision ? (
         <DatePicker
-          value={dayjs(`${selectedYear}-${String(selectedMonth).padStart(2, "0")}-${String(selectedDay).padStart(2, "0")}`)}
+          value={pickerValue}
           onChange={handleDatePickerChange}
           style={{ width: "100%" }}
         />

--- a/web/src/components/CalendarDatePickerControls.tsx
+++ b/web/src/components/CalendarDatePickerControls.tsx
@@ -7,13 +7,13 @@ type SelectOption = {
 };
 
 interface CalendarDatePickerControlsProps {
-	readonly showPrecisionSelector: boolean;
-	readonly availablePrecisions: readonly ImportantDatePrecision[];
-	readonly usesPrecisionLayout: boolean;
-	readonly datePrecision: ImportantDatePrecision;
-  readonly displayYear: number | null;
-  readonly selectedMonth: number;
-  readonly selectedDay: number;
+  readonly showPrecisionSelector: boolean;
+  readonly availablePrecisions: readonly ImportantDatePrecision[];
+  readonly usesPrecisionLayout: boolean;
+  readonly datePrecision: ImportantDatePrecision;
+  readonly displayYear: number | null | undefined;
+  readonly selectedMonth: number | undefined;
+  readonly selectedDay: number | undefined;
   readonly yearOptions: SelectOption[];
   readonly monthOptions: SelectOption[];
   readonly dayOptions: SelectOption[];
@@ -34,9 +34,9 @@ interface CalendarDatePickerControlsProps {
 }
 
 export default function CalendarDatePickerControls({
-	showPrecisionSelector,
-	availablePrecisions,
-	usesPrecisionLayout,
+  showPrecisionSelector,
+  availablePrecisions,
+  usesPrecisionLayout,
   datePrecision,
   displayYear,
   selectedMonth,
@@ -54,23 +54,24 @@ export default function CalendarDatePickerControls({
   onMonthChange,
   onDayChange,
 }: CalendarDatePickerControlsProps) {
-	return (
-		<>
-		  {showPrecisionSelector && (
-			<Segmented
-			  options={availablePrecisions.map((precision) => ({
-				value: precision,
-				label: precision === "full"
-					? precisionLabels.full
-					: precision === "month"
-						? precisionLabels.month
-						: precision === "year"
-							? precisionLabels.year
-							: precisionLabels.monthDay,
-			  }))}
-			  value={datePrecision}
-			  onChange={onPrecisionChange}
-			  style={{ marginBottom: 8 }}
+  return (
+    <>
+      {showPrecisionSelector && (
+        <Segmented
+          options={availablePrecisions.map((precision) => ({
+            value: precision,
+            label:
+              precision === "full"
+                ? precisionLabels.full
+                : precision === "month"
+                  ? precisionLabels.month
+                  : precision === "year"
+                    ? precisionLabels.year
+                    : precisionLabels.monthDay,
+          }))}
+          value={datePrecision}
+          onChange={onPrecisionChange}
+          style={{ marginBottom: 8 }}
           block
         />
       )}
@@ -95,7 +96,9 @@ export default function CalendarDatePickerControls({
             placeholder={monthPlaceholder}
           />
         )}
-        {(!usesPrecisionLayout || datePrecision === "full" || datePrecision === "month_day") && (
+        {(!usesPrecisionLayout ||
+          datePrecision === "full" ||
+          datePrecision === "month_day") && (
           <Select
             value={selectedDay}
             onChange={onDayChange}

--- a/web/src/components/calendarDatePickerHandlers.ts
+++ b/web/src/components/calendarDatePickerHandlers.ts
@@ -18,7 +18,7 @@ type CalendarDatePickerHandlersArgs = {
   readonly selectedMonth: number;
   readonly selectedDay: number;
   readonly noYearValue: number;
-  readonly onChange?: (value: CalendarDatePickerValue) => void;
+  readonly onChange?: (value: CalendarDatePickerValue | null) => void;
 };
 
 export function createCalendarDatePickerHandlers({
@@ -68,7 +68,11 @@ export function createCalendarDatePickerHandlers({
       emit(valueToApply, converted.year, converted.month, converted.day);
     },
 
-    handleGregorianChange(nextYear: number, nextMonth: number, nextDay: number) {
+    handleGregorianChange(
+      nextYear: number,
+      nextMonth: number,
+      nextDay: number,
+    ) {
       emit("gregorian", nextYear, nextMonth, nextDay, "full");
     },
 
@@ -107,7 +111,7 @@ export function createCalendarDatePickerHandlers({
         (monthOption) => monthOption.value === selectedMonth,
       )
         ? selectedMonth
-        : validMonths[0]?.value ?? 1;
+        : (validMonths[0]?.value ?? 1);
       emit(calendarType, nextYear, validMonth, selectedDay);
     },
 
@@ -120,13 +124,7 @@ export function createCalendarDatePickerHandlers({
     },
 
     handleClear() {
-      onChange?.({
-        calendarType,
-        day: null,
-        month: null,
-        year: null,
-        datePrecision,
-      });
+      onChange?.(null);
     },
   };
 }

--- a/web/src/components/calendarDatePickerHandlers.ts
+++ b/web/src/components/calendarDatePickerHandlers.ts
@@ -118,5 +118,15 @@ export function createCalendarDatePickerHandlers({
     handleDayChange(nextDay: number) {
       emit(calendarType, displayYear, selectedMonth, nextDay);
     },
+
+    handleClear() {
+      onChange?.({
+        calendarType,
+        day: null,
+        month: null,
+        year: null,
+        datePrecision,
+      });
+    },
   };
 }

--- a/web/src/pages/vault/VaultDetail.tsx
+++ b/web/src/pages/vault/VaultDetail.tsx
@@ -18,7 +18,6 @@ import {
   Form,
   Input,
   InputNumber,
-  Popconfirm,
   App,
   List,
   Tag,
@@ -95,7 +94,7 @@ export default function VaultDetail() {
   const nameOrder = useNameOrder();
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [form] = Form.useForm();
-  const { message } = App.useApp();
+  const { message, modal } = App.useApp();
   const queryClient = useQueryClient();
 
   // ─── Core Queries ──────────────────────────────────────────────
@@ -215,18 +214,16 @@ export default function VaultDetail() {
       key: "delete",
       danger: true,
       icon: <DeleteOutlined />,
-      label: (
-        <Popconfirm
-          title={t("vault.detail.delete_confirm")}
-          onConfirm={() => deleteMutation.mutate()}
-          okText={t("common.delete")}
-          cancelText={t("common.cancel")}
-        >
-          <div onClick={(e) => e.stopPropagation()}>
-            {t("vault.detail.delete")}
-          </div>
-        </Popconfirm>
-      ),
+      label: t("vault.detail.delete"),
+      onClick: () => {
+        modal.confirm({
+          title: t("vault.detail.delete_confirm"),
+          okText: t("common.delete"),
+          cancelText: t("common.cancel"),
+          okButtonProps: { danger: true },
+          onOk: () => deleteMutation.mutate(),
+        });
+      },
     },
   ];
 
@@ -248,13 +245,19 @@ export default function VaultDetail() {
       <div
         style={{
           display: "flex",
+          flexWrap: "wrap",
           justifyContent: "space-between",
           alignItems: "center",
+          gap: 12,
           marginBottom: 20,
         }}
       >
-        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <Title level={4} style={{ margin: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+          <Title
+            level={4}
+            ellipsis={{ rows: 1, tooltip: vault.name }}
+            style={{ margin: 0, maxWidth: "min(60vw, 480px)" }}
+          >
             {vault.name}
           </Title>
           {vault.current_user_permission === 100 && (

--- a/web/src/test/CalendarDatePicker.test.tsx
+++ b/web/src/test/CalendarDatePicker.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
-import { App as AntApp, ConfigProvider } from "antd";
+import { App as AntApp, Button, ConfigProvider, Form } from "antd";
 import userEvent from "@testing-library/user-event";
 import CalendarDatePicker from "@/components/CalendarDatePicker";
+import CalendarAwareDatePicker from "@/components/CalendarAwareDatePicker";
+import dayjs from "dayjs";
 
 beforeAll(() => {
   globalThis.ResizeObserver = class {
@@ -29,28 +31,49 @@ describe("CalendarDatePicker", () => {
     renderPicker({
       enableNoYear: true,
       enableDatePrecision: true,
-      value: { calendarType: "gregorian", day: 15, month: 8, year: 2025, datePrecision: "full" },
+      value: {
+        calendarType: "gregorian",
+        day: 15,
+        month: 8,
+        year: 2025,
+        datePrecision: "full",
+      },
       onChange,
     });
 
     await user.click(screen.getByText("Month & year"));
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({ day: null, month: 8, year: 2025, datePrecision: "month" }),
+        expect.objectContaining({
+          day: null,
+          month: 8,
+          year: 2025,
+          datePrecision: "month",
+        }),
       );
     });
 
     await user.click(screen.getByText("Year only"));
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({ day: null, month: null, year: 2025, datePrecision: "year" }),
+        expect.objectContaining({
+          day: null,
+          month: null,
+          year: 2025,
+          datePrecision: "year",
+        }),
       );
     });
 
     await user.click(screen.getByText("Month & day"));
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({ day: 15, month: 8, year: null, datePrecision: "month_day" }),
+        expect.objectContaining({
+          day: 15,
+          month: 8,
+          year: null,
+          datePrecision: "month_day",
+        }),
       );
     });
   });
@@ -59,7 +82,13 @@ describe("CalendarDatePicker", () => {
     renderPicker({
       enableDatePrecision: true,
       allowedDatePrecisions: ["full", "month", "year"],
-      value: { calendarType: "gregorian", day: 15, month: 8, year: 2025, datePrecision: "full" },
+      value: {
+        calendarType: "gregorian",
+        day: 15,
+        month: 8,
+        year: 2025,
+        datePrecision: "full",
+      },
     });
 
     expect(screen.queryByText("Month & day")).not.toBeInTheDocument();
@@ -77,9 +106,23 @@ describe("CalendarDatePicker", () => {
 
   it("shows an empty input instead of today's date when value is missing", () => {
     renderPicker();
-    const input = document.querySelector(".ant-picker-input input") as HTMLInputElement;
+    const input = document.querySelector(
+      ".ant-picker-input input",
+    ) as HTMLInputElement;
     expect(input).toBeInTheDocument();
     expect(input.value).toBe("");
+  });
+
+  it("shows placeholders instead of today's date in the precision layout", () => {
+    renderPicker({
+      enableDatePrecision: true,
+      allowedDatePrecisions: ["full", "month_day"],
+    });
+
+    const placeholders = Array.from(
+      document.querySelectorAll(".ant-select-placeholder"),
+    ).map((element) => element.textContent);
+    expect(placeholders).toEqual(["Year", "Month", "Day"]);
   });
 
   it("clears the value when the clear button is clicked", async () => {
@@ -95,14 +138,45 @@ describe("CalendarDatePicker", () => {
     await user.click(clearButton as Element);
 
     await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith({
-        calendarType: "gregorian",
-        day: null,
-        month: null,
-        year: null,
-        datePrecision: "full",
-      });
+      expect(onChange).toHaveBeenCalledWith(null);
     });
+  });
+
+  it("keeps a cleared picker empty for required Form validation", async () => {
+    const user = userEvent.setup();
+    const onFinish = vi.fn();
+    const onFinishFailed = vi.fn();
+    render(
+      <ConfigProvider>
+        <AntApp>
+          <Form
+            initialValues={{
+              calendarDate: {
+                calendarType: "gregorian",
+                day: 15,
+                month: 8,
+                year: 2025,
+              },
+            }}
+            onFinish={onFinish}
+            onFinishFailed={onFinishFailed}
+          >
+            <Form.Item name="calendarDate" rules={[{ required: true }]}>
+              <CalendarDatePicker />
+            </Form.Item>
+            <Button htmlType="submit">Submit</Button>
+          </Form>
+        </AntApp>
+      </ConfigProvider>,
+    );
+
+    const clearButton = document.querySelector(".ant-picker-clear");
+    expect(clearButton).not.toBeNull();
+    await user.click(clearButton as Element);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => expect(onFinishFailed).toHaveBeenCalledOnce());
+    expect(onFinish).not.toHaveBeenCalled();
   });
 
   it("renders with segmented calendar switcher when enabled", () => {
@@ -129,7 +203,13 @@ describe("CalendarDatePicker", () => {
     renderPicker({
       enableAlternativeCalendar: true,
       enableDatePrecision: true,
-      value: { calendarType: "lunar", day: 15, month: 1, year: 2025, datePrecision: "full" },
+      value: {
+        calendarType: "lunar",
+        day: 15,
+        month: 1,
+        year: 2025,
+        datePrecision: "full",
+      },
       onChange,
     });
 
@@ -181,7 +261,13 @@ describe("CalendarDatePicker", () => {
     renderPicker({
       enableAlternativeCalendar: true,
       enableNoYear: true,
-      value: { calendarType: "lunar", day: 15, month: 1, year: null, datePrecision: "month_day" },
+      value: {
+        calendarType: "lunar",
+        day: 15,
+        month: 1,
+        year: null,
+        datePrecision: "month_day",
+      },
     });
     const yearSelect = document.querySelector(".ant-select");
     expect(yearSelect).toBeTruthy();
@@ -229,5 +315,52 @@ describe("CalendarDatePicker", () => {
         expect.objectContaining({ year: null, datePrecision: "month_day" }),
       );
     });
+  });
+});
+
+describe("CalendarAwareDatePicker", () => {
+  it("renders an empty alternative-calendar picker when the form value is empty", () => {
+    render(
+      <ConfigProvider>
+        <AntApp>
+          <CalendarAwareDatePicker enableAlternativeCalendar value={null} />
+        </AntApp>
+      </ConfigProvider>,
+    );
+
+    const input = document.querySelector(
+      ".ant-picker-input input",
+    ) as HTMLInputElement;
+    expect(input.value).toBe("");
+    expect(screen.queryByText(/Chinese Lunar:/)).not.toBeInTheDocument();
+  });
+
+  it("forwards clear as null in the alternative-calendar path", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ConfigProvider>
+        <AntApp>
+          <CalendarAwareDatePicker
+            enableAlternativeCalendar
+            allowClear
+            value={{
+              date: dayjs("2025-08-15"),
+              calendarType: "gregorian",
+              originalDay: null,
+              originalMonth: null,
+              originalYear: null,
+            }}
+            onChange={onChange}
+          />
+        </AntApp>
+      </ConfigProvider>,
+    );
+
+    const clearButton = document.querySelector(".ant-picker-clear");
+    expect(clearButton).not.toBeNull();
+    await user.click(clearButton as Element);
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(null));
   });
 });

--- a/web/src/test/CalendarDatePicker.test.tsx
+++ b/web/src/test/CalendarDatePicker.test.tsx
@@ -75,6 +75,36 @@ describe("CalendarDatePicker", () => {
     expect(screen.queryByText("Chinese Lunar")).not.toBeInTheDocument();
   });
 
+  it("shows an empty input instead of today's date when value is missing", () => {
+    renderPicker();
+    const input = document.querySelector(".ant-picker-input input") as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe("");
+  });
+
+  it("clears the value when the clear button is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderPicker({
+      value: { calendarType: "gregorian", day: 15, month: 8, year: 2025 },
+      onChange,
+    });
+
+    const clearButton = document.querySelector(".ant-picker-clear");
+    expect(clearButton).not.toBeNull();
+    await user.click(clearButton as Element);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        calendarType: "gregorian",
+        day: null,
+        month: null,
+        year: null,
+        datePrecision: "full",
+      });
+    });
+  });
+
   it("renders with segmented calendar switcher when enabled", () => {
     renderPicker({ enableAlternativeCalendar: true });
     expect(screen.getByText("Gregorian")).toBeInTheDocument();


### PR DESCRIPTION
## Summary（概述）

Fixes #234 (date picker interaction and vault detail UI).

### Problem 1: clear button swallowed（清除按钮无效）

`CalendarDatePicker.handleDatePickerChange(null)` returned early, so the antd DatePicker clear button silently did nothing — task due dates / journal dates could not be cleared in the plain DatePicker branch.

**Fix**: the picker now emits a cleared value (`day/month/year: null`, precision preserved) via a new `handleClear` handler in `calendarDatePickerHandlers.ts`. The plain-gregorian branch (`CalendarAwareDatePicker`) already forwarded nulls correctly and is unaffected.

### Problem 2: empty value rendered as today（空值显示今天）

When `value` was undefined, the component fell back to today's date and `value={dayjs(...)}` was never null — the input looked pre-filled while the form value stayed undefined, causing confusing required-field validation errors (e.g. RemindersModule).

**Fix**: the DatePicker `value` is now `null` when no day/month is selected (placeholder shown, empty input).

### Problem 3: delete popconfirm overlapped the dropdown menu（删除确认与菜单重叠）

The settings menu's delete item embedded a `<Popconfirm>` inside a `stopPropagation` div, so the Dropdown never closed and the popup rendered on top of the open menu.

**Fix** (`web/src/pages/vault/VaultDetail.tsx`): the delete item now opens `modal.confirm` from `App.useApp()` (danger OK button), the menu closes normally, and the popup is a proper centered modal.

### Problem 4: header overflowed on narrow screens（窄屏页头溢出）

The header flex row had no wrap and the title no ellipsis, producing a page-level horizontal scrollbar below 768px.

**Fix**: `flexWrap: "wrap"` + gap on the header, and `ellipsis` (with tooltip) + max-width on the title.

## Tests（测试）

- `web/src/test/CalendarDatePicker.test.tsx` — empty value renders empty input (not today); clear button emits `{day: null, month: null, year: null}`
- `bun run lint` ✓, `bun run build` ✓, full `bun run test` (860 tests) ✓