### PR TITLE
fix: contact move and account deletion data safety

### DIFF
--- a/server/internal/services/admin.go
+++ b/server/internal/services/admin.go
@@ -213,6 +213,11 @@ func (s *AdminService) deleteEntireAccount(user models.User) error {
 			return fmt.Errorf("delete call reasons: %w", err)
 		}
 
+		postTemplateSubquery := tx.Model(&models.PostTemplate{}).Select("id").Where("account_id = ?", user.AccountID)
+		if err := tx.Where("post_template_id IN (?)", postTemplateSubquery).Delete(&models.PostTemplateSection{}).Error; err != nil {
+			return fmt.Errorf("delete post template sections: %w", err)
+		}
+
 		accountTables := []interface{}{
 			&models.Invitation{},
 			&models.AccountCurrency{},
@@ -228,7 +233,6 @@ func (s *AdminService) deleteEntireAccount(user models.User) error {
 			&models.Emotion{},
 			&models.GiftOccasion{},
 			&models.GiftState{},
-			&models.PostTemplateSection{},
 			&models.PostTemplate{},
 			&models.GroupType{},
 			&models.SyncToken{},

--- a/server/internal/services/admin.go
+++ b/server/internal/services/admin.go
@@ -186,12 +186,7 @@ func (s *AdminService) DeleteUser(actorID, targetID string) error {
 
 // deleteEntireAccount removes the user, the account, and all associated data (vaults, contacts, files, etc.).
 func (s *AdminService) deleteEntireAccount(user models.User) error {
-	// Delete physical files BEFORE the transaction to avoid SQLite lock contention.
-	if err := s.deleteUserFiles(user.AccountID); err != nil {
-		return fmt.Errorf("delete user files: %w", err)
-	}
-
-	return s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.db.Transaction(func(tx *gorm.DB) error {
 		var vaults []models.Vault
 		if err := tx.Where("account_id = ?", user.AccountID).Find(&vaults).Error; err != nil {
 			return err
@@ -233,6 +228,7 @@ func (s *AdminService) deleteEntireAccount(user models.User) error {
 			&models.Emotion{},
 			&models.GiftOccasion{},
 			&models.GiftState{},
+			&models.PostTemplateSection{},
 			&models.PostTemplate{},
 			&models.GroupType{},
 			&models.SyncToken{},
@@ -256,8 +252,18 @@ func (s *AdminService) deleteEntireAccount(user models.User) error {
 			return err
 		}
 
-		return tx.Where("id = ?", user.AccountID).Delete(&models.Account{}).Error
+		if err := tx.Where("id = ?", user.AccountID).Delete(&models.Account{}).Error; err != nil {
+			return err
+		}
+		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	// Delete physical files only after the transaction commits: a rollback must
+	// not leave the account without the files it still references.
+	return s.deleteUserFiles(user.AccountID)
 }
 
 // deleteUserOnly removes only the user record and their personal data (notification channels,

--- a/server/internal/services/admin.go
+++ b/server/internal/services/admin.go
@@ -186,7 +186,17 @@ func (s *AdminService) DeleteUser(actorID, targetID string) error {
 
 // deleteEntireAccount removes the user, the account, and all associated data (vaults, contacts, files, etc.).
 func (s *AdminService) deleteEntireAccount(user models.User) error {
+	var fileUUIDs []string
 	err := s.db.Transaction(func(tx *gorm.DB) error {
+		// Collect physical file paths while the rows still exist; the files
+		// themselves are removed only after the transaction commits.
+		if err := tx.Model(&models.File{}).
+			Joins("INNER JOIN vaults ON files.vault_id = vaults.id").
+			Where("vaults.account_id = ?", user.AccountID).
+			Pluck("uuid", &fileUUIDs).Error; err != nil {
+			return fmt.Errorf("collect user files: %w", err)
+		}
+
 		var vaults []models.Vault
 		if err := tx.Where("account_id = ?", user.AccountID).Find(&vaults).Error; err != nil {
 			return err
@@ -267,7 +277,7 @@ func (s *AdminService) deleteEntireAccount(user models.User) error {
 
 	// Delete physical files only after the transaction commits: a rollback must
 	// not leave the account without the files it still references.
-	return s.deleteUserFiles(user.AccountID)
+	return s.removeFiles(fileUUIDs)
 }
 
 // deleteUserOnly removes only the user record and their personal data (notification channels,
@@ -458,14 +468,9 @@ func (s *AdminService) deleteContactData(tx *gorm.DB, contactID string) error {
 	return nil
 }
 
-func (s *AdminService) deleteUserFiles(accountID string) error {
-	var files []models.File
-	s.db.Joins("INNER JOIN vaults ON files.vault_id = vaults.id").
-		Where("vaults.account_id = ?", accountID).
-		Find(&files)
-
-	for _, f := range files {
-		filePath := filepath.Join(s.uploadDir, f.UUID)
+func (s *AdminService) removeFiles(fileUUIDs []string) error {
+	for _, uuid := range fileUUIDs {
+		filePath := filepath.Join(s.uploadDir, uuid)
 		os.Remove(filePath)
 	}
 	return nil

--- a/server/internal/services/admin_test.go
+++ b/server/internal/services/admin_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -297,6 +298,53 @@ func TestAdminDeleteUser_Success(t *testing.T) {
 	adminSvc.db.Model(&models.ContactTask{}).Where("vault_id = ?", vault.ID).Count(&taskCount)
 	if taskCount != 0 {
 		t.Error("expected standalone vault tasks to be deleted")
+	}
+}
+
+func TestAdminDeleteUser_RemovesPhysicalFilesAfterCommit(t *testing.T) {
+	tmpDir := t.TempDir()
+	uploadDir := filepath.Join(tmpDir, "uploads")
+	db, err := database.Connect(&config.DatabaseConfig{Driver: "sqlite", DSN: filepath.Join(tmpDir, "bonds.db")}, false)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	if err := database.AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+	adminSvc := NewAdminService(db, uploadDir)
+	authSvc := NewAuthService(db, testutil.TestJWTConfig())
+	vaultSvc := NewVaultService(db)
+
+	admin := registerTestUser(t, authSvc, "del-files-admin@example.com")
+	target := registerTestUser(t, authSvc, "del-files-target@example.com")
+
+	vault, err := vaultSvc.CreateVault(target.User.AccountID, target.User.ID, dto.CreateVaultRequest{Name: "Files Vault"}, "en")
+	if err != nil {
+		t.Fatalf("CreateVault failed: %v", err)
+	}
+
+	fileUUID := filepath.Join("2026", "08", "19", "vault-file.bin")
+	diskPath := filepath.Join(uploadDir, fileUUID)
+	if err := os.MkdirAll(filepath.Dir(diskPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(diskPath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	fileType := "document"
+	if err := adminSvc.db.Create(&models.File{
+		VaultID: vault.ID, FileableType: &fileType, UUID: fileUUID,
+		Name: "vault-file.bin", Type: "document", MimeType: "application/octet-stream", Size: 7,
+	}).Error; err != nil {
+		t.Fatalf("Create File failed: %v", err)
+	}
+
+	if err := adminSvc.DeleteUser(admin.User.ID, target.User.ID); err != nil {
+		t.Fatalf("DeleteUser failed: %v", err)
+	}
+
+	if _, err := os.Stat(diskPath); !os.IsNotExist(err) {
+		t.Errorf("expected physical file %s to be removed after account deletion, stat err: %v", diskPath, err)
 	}
 }
 

--- a/server/internal/services/contact_move.go
+++ b/server/internal/services/contact_move.go
@@ -540,13 +540,22 @@ func cleanMovedContactsFromActivities(tx *gorm.DB, contactIDs []string, currentV
 	if err := tx.Where("contact_id IN ?", contactIDs).Delete(&models.ActivityParticipant{}).Error; err != nil {
 		return err
 	}
+	var orphanActivityIDs []uint
 	if err := tx.Model(&models.Activity{}).
-		Where("parent_id IN ?", affectedActivityIDs).
+		Where("vault_id = ? AND id IN ? AND subject_user_id IS NULL", currentVaultID, affectedActivityIDs).
+		Where("NOT EXISTS (?)", tx.Model(&models.ActivityParticipant{}).
+			Select("1").
+			Where("activity_participants.activity_id = activities.id")).
+		Pluck("id", &orphanActivityIDs).Error; err != nil {
+		return err
+	}
+	if len(orphanActivityIDs) == 0 {
+		return nil
+	}
+	if err := tx.Model(&models.Activity{}).
+		Where("parent_id IN ?", orphanActivityIDs).
 		Update("parent_id", nil).Error; err != nil {
 		return err
 	}
-	return tx.
-		Where("vault_id = ? AND id IN ? AND id NOT IN (?)", currentVaultID, affectedActivityIDs,
-			tx.Model(&models.ActivityParticipant{}).Select("activity_id")).
-		Delete(&models.Activity{}).Error
+	return tx.Where("id IN ?", orphanActivityIDs).Delete(&models.Activity{}).Error
 }

--- a/server/internal/services/contact_move.go
+++ b/server/internal/services/contact_move.go
@@ -527,21 +527,26 @@ func cloneFloat64Ptr(value *float64) *float64 {
 }
 
 func cleanMovedContactsFromActivities(tx *gorm.DB, contactIDs []string, currentVaultID string) error {
-	affectedActivityIDs := tx.Model(&models.ActivityParticipant{}).
-		Select("activity_id").
-		Where("contact_id IN ?", contactIDs)
+	var affectedActivityIDs []uint
+	if err := tx.Model(&models.ActivityParticipant{}).
+		Where("contact_id IN ?", contactIDs).
+		Distinct().
+		Pluck("activity_id", &affectedActivityIDs).Error; err != nil {
+		return err
+	}
+	if len(affectedActivityIDs) == 0 {
+		return nil
+	}
 	if err := tx.Where("contact_id IN ?", contactIDs).Delete(&models.ActivityParticipant{}).Error; err != nil {
 		return err
 	}
-	doomed := tx.Model(&models.Activity{}).
-		Select("id").
-		Where("vault_id = ?", currentVaultID).
-		Where("id IN (?)", affectedActivityIDs).
-		Where("id NOT IN (?)", tx.Model(&models.ActivityParticipant{}).Select("activity_id"))
 	if err := tx.Model(&models.Activity{}).
-		Where("parent_id IN (?)", doomed).
+		Where("parent_id IN ?", affectedActivityIDs).
 		Update("parent_id", nil).Error; err != nil {
 		return err
 	}
-	return tx.Where("vault_id = ? AND id IN (?)", currentVaultID, doomed).Delete(&models.Activity{}).Error
+	return tx.
+		Where("vault_id = ? AND id IN ? AND id NOT IN (?)", currentVaultID, affectedActivityIDs,
+			tx.Model(&models.ActivityParticipant{}).Select("activity_id")).
+		Delete(&models.Activity{}).Error
 }

--- a/server/internal/services/contact_move.go
+++ b/server/internal/services/contact_move.go
@@ -78,7 +78,7 @@ func (s *ContactMoveService) MoveMany(contactIDs []string, currentVaultID, targe
 				return err
 			}
 			sourceDAVDeleteTargets = sourceTargets
-			if err := updateBatchFirstMetThrough(tx, uniqueContactIDs); err != nil {
+			if err := updateBatchFirstMetThrough(tx, uniqueContactIDs, currentVaultID); err != nil {
 				return err
 			}
 			if err := moveAllContactRows(tx, uniqueContactIDs, currentVaultID, targetVaultID); err != nil {
@@ -107,7 +107,7 @@ func (s *ContactMoveService) MoveMany(contactIDs []string, currentVaultID, targe
 			if err := cleanSourceScopedMovePivots(tx, uniqueContactIDs, currentVaultID); err != nil {
 				return err
 			}
-			if err := cleanMovedContactsFromActivities(tx, uniqueContactIDs); err != nil {
+			if err := cleanMovedContactsFromActivities(tx, uniqueContactIDs, currentVaultID); err != nil {
 				return err
 			}
 		}
@@ -200,9 +200,9 @@ func validateMoveVaultsAndTargetAccess(tx *gorm.DB, currentVaultID, targetVaultI
 	return NewVaultService(tx).CheckUserVaultAccess(userID, targetVaultID, models.PermissionEditor)
 }
 
-func updateBatchFirstMetThrough(tx *gorm.DB, contactIDs []string) error {
+func updateBatchFirstMetThrough(tx *gorm.DB, contactIDs []string, currentVaultID string) error {
 	return tx.Model(&models.Contact{}).
-		Where("id IN ? AND first_met_through_contact_id IS NOT NULL AND first_met_through_contact_id NOT IN ?", contactIDs, contactIDs).
+		Where("vault_id = ? AND id IN ? AND first_met_through_contact_id IS NOT NULL AND first_met_through_contact_id NOT IN ?", currentVaultID, contactIDs, contactIDs).
 		Update("first_met_through_contact_id", nil).Error
 }
 
@@ -526,13 +526,22 @@ func cloneFloat64Ptr(value *float64) *float64 {
 	return &copyValue
 }
 
-func cleanMovedContactsFromActivities(tx *gorm.DB, contactIDs []string) error {
+func cleanMovedContactsFromActivities(tx *gorm.DB, contactIDs []string, currentVaultID string) error {
+	affectedActivityIDs := tx.Model(&models.ActivityParticipant{}).
+		Select("activity_id").
+		Where("contact_id IN ?", contactIDs)
 	if err := tx.Where("contact_id IN ?", contactIDs).Delete(&models.ActivityParticipant{}).Error; err != nil {
 		return err
 	}
-	orphans := tx.Model(&models.ActivityParticipant{}).Select("activity_id")
-	if err := tx.Model(&models.Activity{}).Where("id NOT IN (?)", orphans).Update("parent_id", nil).Error; err != nil {
+	doomed := tx.Model(&models.Activity{}).
+		Select("id").
+		Where("vault_id = ?", currentVaultID).
+		Where("id IN (?)", affectedActivityIDs).
+		Where("id NOT IN (?)", tx.Model(&models.ActivityParticipant{}).Select("activity_id"))
+	if err := tx.Model(&models.Activity{}).
+		Where("parent_id IN (?)", doomed).
+		Update("parent_id", nil).Error; err != nil {
 		return err
 	}
-	return tx.Where("id NOT IN (?)", orphans).Delete(&models.Activity{}).Error
+	return tx.Where("vault_id = ? AND id IN (?)", currentVaultID, doomed).Delete(&models.Activity{}).Error
 }

--- a/server/internal/services/contact_move_test.go
+++ b/server/internal/services/contact_move_test.go
@@ -418,6 +418,76 @@ func TestMoveManyCleansActivityPivotsAndOrphanEvent(t *testing.T) {
 	assertMoveCount(t, svc, &models.Activity{}, "id = ?", 0, created.ID)
 }
 
+func TestMoveManyPreservesUserSubjectActivityAfterLastContactParticipantMoves(t *testing.T) {
+	svc, contactID, vault1ID, vault2ID, userID := setupContactMoveTest(t)
+	activitySvc := NewActivityService(svc.db)
+	typeID := getActivityTypeIDForMoveVault(t, svc, vault1ID)
+	started := time.Now()
+	participantIDs := []string{contactID}
+	created, err := activitySvc.CreateForUser(vault1ID, userID, dto.ActivityUpsertRequest{
+		ActivityTypeID: typeID,
+		ParticipantIDs: &participantIDs,
+		StartDate:      &started,
+		Title:          "User subject with contact participant",
+	})
+	if err != nil {
+		t.Fatalf("Create user-subject activity failed: %v", err)
+	}
+
+	if _, err := svc.MoveMany([]string{contactID}, vault1ID, vault2ID, userID); err != nil {
+		t.Fatalf("MoveMany failed: %v", err)
+	}
+
+	assertMoveCount(t, svc, &models.ActivityParticipant{}, "activity_id = ?", 0, created.ID)
+	assertMoveCount(t, svc, &models.Activity{}, "id = ? AND vault_id = ? AND subject_user_id = ?", 1, created.ID, vault1ID, userID)
+}
+
+func TestMoveManyKeepsMilestoneAttachedWhenAffectedParentSurvives(t *testing.T) {
+	svc, contactID, vault1ID, vault2ID, userID := setupContactMoveTest(t)
+	contactSvc := NewContactService(svc.db)
+	remaining, err := contactSvc.CreateContact(vault1ID, userID, dto.CreateContactRequest{FirstName: "Remaining"})
+	if err != nil {
+		t.Fatalf("Create remaining participant failed: %v", err)
+	}
+	activitySvc := NewActivityService(svc.db)
+	typeID := getActivityTypeIDForMoveVault(t, svc, vault1ID)
+	started := time.Now()
+	participantIDs := []string{remaining.ID}
+	parent, err := activitySvc.Create(vault1ID, dto.ActivityUpsertRequest{
+		ActivityTypeID:   typeID,
+		PrimaryContactID: contactID,
+		ParticipantIDs:   &participantIDs,
+		StartDate:        &started,
+		Title:            "Parent with remaining participant",
+	})
+	if err != nil {
+		t.Fatalf("Create parent activity failed: %v", err)
+	}
+	milestone, err := activitySvc.Create(vault1ID, dto.ActivityUpsertRequest{
+		ActivityTypeID:   typeID,
+		PrimaryContactID: remaining.ID,
+		ParentID:         &parent.ID,
+		StartDate:        &started,
+		Title:            "Milestone",
+	})
+	if err != nil {
+		t.Fatalf("Create milestone failed: %v", err)
+	}
+
+	if _, err := svc.MoveMany([]string{contactID}, vault1ID, vault2ID, userID); err != nil {
+		t.Fatalf("MoveMany failed: %v", err)
+	}
+
+	assertMoveCount(t, svc, &models.Activity{}, "id = ?", 1, parent.ID)
+	var reloadedMilestone models.Activity
+	if err := svc.db.First(&reloadedMilestone, milestone.ID).Error; err != nil {
+		t.Fatalf("Reload milestone failed: %v", err)
+	}
+	if reloadedMilestone.ParentID == nil || *reloadedMilestone.ParentID != parent.ID {
+		t.Fatalf("expected milestone parent_id %d to be preserved, got %v", parent.ID, reloadedMilestone.ParentID)
+	}
+}
+
 func TestMoveManyAllowsArchivedContacts(t *testing.T) {
 	svc, _, vault1ID, vault2ID, userID := setupContactMoveTest(t)
 	listed := false


### PR DESCRIPTION
Closes #237

## Summary / 概述

Contact move and account deletion data-safety fixes.

联系人移动与账户删除的数据安全修复。

## Changes / 变更

- **B1 — Move must not delete activities across the whole account**: activity cleanup is now scoped to the source vault and only touches activities the moved contacts actually participated in; sub-activity `parent_id` links are cleared before orphan deletion (修复前跨 vault/跨账户删除全库零参与者活动).
- **B2 — Account deletion FK failure + file deletion order**: `PostTemplateSection` rows are removed via a `post_template_id IN (…)` subquery (the table has no `account_id` column, so the old blanket `account_id` delete is invalid with SQLite foreign keys on); physical files are now deleted only after the transaction commits — UUIDs are collected inside the transaction and removed after commit, so a rollback never loses files a still-existing account references (修复前 FK 500 与回滚后文件丢失/提交后文件永不删除).
- **B3 — first_met_through cleared across vaults on move**: the clearing update is additionally filtered by the source vault (防御性修复).

## Verification / 验证

- Go: `go build ./...` + `go vet ./...` clean; full service + handler test suites pass on Linux (cgo/SQLite), including the new `TestAdminDeleteUser_RemovesPhysicalFilesAfterCommit` regression test.