### PR TITLE
fix: schedule imported reminders and reject currency personalize writes

### DIFF
--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -7028,6 +7028,38 @@ func TestPersonalizeUpdatePositionUnsupportedEntityReturnsBadRequest(t *testing.
 	}
 }
 
+func TestPersonalizeCurrencyWritesReturnLocalizedBadRequest(t *testing.T) {
+	ts := setupTestServer(t)
+	token, _ := ts.registerTestUser(t, "personalize-currency-writes@example.com")
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{name: "create", method: http.MethodPost, path: "/api/settings/personalize/currencies", body: `{"name":"USD"}`},
+		{name: "update", method: http.MethodPut, path: "/api/settings/personalize/currencies/1", body: `{"name":"USD"}`},
+		{name: "delete", method: http.MethodDelete, path: "/api/settings/personalize/currencies/1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := ts.doRequest(tc.method, tc.path, tc.body, token)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+			}
+			resp := parseResponse(t, rec)
+			if resp.Error == nil || resp.Error.Code != "BAD_REQUEST" {
+				t.Fatalf("expected BAD_REQUEST error, got %#v", resp.Error)
+			}
+			if resp.Error.Message != "Currencies cannot be created, edited, or deleted" {
+				t.Fatalf("unexpected localized message %q", resp.Error.Message)
+			}
+		})
+	}
+}
+
 func (ts *testServer) generateOAuthLinkToken(t *testing.T) string {
 	t.Helper()
 	oauthSvc := services.NewOAuthService(ts.db, &ts.cfg.JWT)

--- a/server/internal/handlers/personalize.go
+++ b/server/internal/handlers/personalize.go
@@ -74,6 +74,9 @@ func (h *PersonalizeHandler) Create(c echo.Context) error {
 		if errors.Is(err, services.ErrUnknownEntityType) {
 			return response.NotFound(c, "err.unknown_entity_type")
 		}
+		if errors.Is(err, services.ErrCurrenciesNotEditable) {
+			return response.BadRequest(c, "err.currencies_not_editable", nil)
+		}
 		return response.InternalError(c, "err.failed_to_create_entity")
 	}
 	return response.Created(c, item)
@@ -115,6 +118,9 @@ func (h *PersonalizeHandler) Update(c echo.Context) error {
 		if errors.Is(err, services.ErrPersonalizeEntityNotFound) {
 			return response.NotFound(c, "err.entity_not_found")
 		}
+		if errors.Is(err, services.ErrCurrenciesNotEditable) {
+			return response.BadRequest(c, "err.currencies_not_editable", nil)
+		}
 		return response.InternalError(c, "err.failed_to_update_entity")
 	}
 	return response.OK(c, item)
@@ -147,6 +153,9 @@ func (h *PersonalizeHandler) Delete(c echo.Context) error {
 		}
 		if errors.Is(err, services.ErrPersonalizeEntityNotFound) {
 			return response.NotFound(c, "err.entity_not_found")
+		}
+		if errors.Is(err, services.ErrCurrenciesNotEditable) {
+			return response.BadRequest(c, "err.currencies_not_editable", nil)
 		}
 		return response.InternalError(c, "err.failed_to_delete_entity")
 	}

--- a/server/internal/i18n/de.json
+++ b/server/internal/i18n/de.json
@@ -218,6 +218,7 @@
   "err.failed_to_list_templates": "Vorlagen konnten nicht aufgelistet werden",
   "err.failed_to_list_modules": "Module konnten nicht aufgelistet werden",
   "err.unknown_entity_type": "Unbekannter Entitätstyp",
+  "err.currencies_not_editable": "Währungen können nicht erstellt, bearbeitet oder gelöscht werden",
   "err.failed_to_list_entities": "Entitäten konnten nicht aufgelistet werden",
   "err.failed_to_create_entity": "Entität konnte nicht erstellt werden",
   "err.invalid_entity_id": "Ungültige Entitäts-ID",

--- a/server/internal/i18n/en.json
+++ b/server/internal/i18n/en.json
@@ -218,6 +218,7 @@
   "err.failed_to_list_templates": "Failed to list templates",
   "err.failed_to_list_modules": "Failed to list modules",
   "err.unknown_entity_type": "Unknown entity type",
+  "err.currencies_not_editable": "Currencies cannot be created, edited, or deleted",
   "err.failed_to_list_entities": "Failed to list entities",
   "err.failed_to_create_entity": "Failed to create entity",
   "err.invalid_entity_id": "Invalid entity ID",

--- a/server/internal/i18n/es.json
+++ b/server/internal/i18n/es.json
@@ -186,6 +186,7 @@
   "err.failed_to_list_templates": "Error al listar las plantillas",
   "err.failed_to_list_modules": "Error al listar los módulos",
   "err.unknown_entity_type": "Tipo de entidad desconocido",
+  "err.currencies_not_editable": "Las monedas no se pueden crear, editar ni eliminar",
   "err.failed_to_list_entities": "Error al listar las entidades",
   "err.failed_to_create_entity": "Error al crear la entidad",
   "err.invalid_entity_id": "ID de entidad inválido",

--- a/server/internal/i18n/fr.json
+++ b/server/internal/i18n/fr.json
@@ -186,6 +186,7 @@
   "err.failed_to_list_templates": "Échec de la liste des modèles",
   "err.failed_to_list_modules": "Échec de la liste des modules",
   "err.unknown_entity_type": "Type d'entité inconnu",
+  "err.currencies_not_editable": "Les devises ne peuvent pas être créées, modifiées ou supprimées",
   "err.failed_to_list_entities": "Échec de la liste des entités",
   "err.failed_to_create_entity": "Échec de la création de l'entité",
   "err.invalid_entity_id": "ID d'entité invalide",

--- a/server/internal/i18n/pt-BR.json
+++ b/server/internal/i18n/pt-BR.json
@@ -186,6 +186,7 @@
   "err.failed_to_list_templates": "Falha ao listar modelos",
   "err.failed_to_list_modules": "Falha ao listar módulos",
   "err.unknown_entity_type": "Tipo de entidade desconhecido",
+  "err.currencies_not_editable": "As moedas não podem ser criadas, editadas ou excluídas",
   "err.failed_to_list_entities": "Falha ao listar entidades",
   "err.failed_to_create_entity": "Falha ao criar entidade",
   "err.invalid_entity_id": "ID da entidade inválido",

--- a/server/internal/i18n/pt-PT.json
+++ b/server/internal/i18n/pt-PT.json
@@ -186,6 +186,7 @@
   "err.failed_to_list_templates": "Falha ao listar modelos",
   "err.failed_to_list_modules": "Falha ao listar módulos",
   "err.unknown_entity_type": "Tipo de entidade desconhecido",
+  "err.currencies_not_editable": "As moedas não podem ser criadas, editadas ou eliminadas",
   "err.failed_to_list_entities": "Falha ao listar entidades",
   "err.failed_to_create_entity": "Falha ao criar entidade",
   "err.invalid_entity_id": "ID de entidade inválido",

--- a/server/internal/i18n/zh.json
+++ b/server/internal/i18n/zh.json
@@ -218,6 +218,7 @@
   "err.failed_to_list_templates": "获取模板列表失败",
   "err.failed_to_list_modules": "获取模块列表失败",
   "err.unknown_entity_type": "未知的实体类型",
+  "err.currencies_not_editable": "货币不能创建、编辑或删除",
   "err.failed_to_list_entities": "获取实体列表失败",
   "err.failed_to_create_entity": "创建实体失败",
   "err.invalid_entity_id": "无效的实体ID",

--- a/server/internal/services/monica_import.go
+++ b/server/internal/services/monica_import.go
@@ -671,6 +671,9 @@ func (s *MonicaImportService) importReminders(
 		}
 		if err := tx.Create(&reminder).Error; err == nil {
 			resp.ImportedReminders++
+			if err := scheduleReminderForVaultUsers(tx, &reminder); err != nil {
+				resp.Errors = append(resp.Errors, fmt.Sprintf("reminder %s: could not schedule reminder", mr.UUID))
+			}
 			if mr.Properties.Description != "" {
 				sourceType := "monica_reminder_description"
 				sourceUUID := mr.UUID

--- a/server/internal/services/personalize.go
+++ b/server/internal/services/personalize.go
@@ -13,6 +13,7 @@ import (
 var ErrPersonalizeEntityNotFound = errors.New("entity not found")
 var ErrUnknownEntityType = errors.New("unknown entity type")
 var ErrPersonalizeEntityNotSortable = errors.New("entity is not sortable")
+var ErrCurrenciesNotEditable = errors.New("currencies are curated via the dedicated toggle APIs")
 
 type PersonalizeService struct {
 	db *gorm.DB
@@ -103,6 +104,10 @@ func (s *PersonalizeService) Create(accountID, entity string, req dto.Personaliz
 		return s.createTaskStatus(accountID, req)
 	}
 
+	if entity == "currencies" {
+		return nil, ErrCurrenciesNotEditable
+	}
+
 	labelCol := s.getLabelCol(cfg)
 	nameCol := s.getNameCol(cfg)
 	val := req.Label
@@ -159,6 +164,10 @@ func (s *PersonalizeService) Update(accountID, entity string, id uint, req dto.P
 		val = req.Name
 	}
 
+	if entity == "currencies" {
+		return nil, ErrCurrenciesNotEditable
+	}
+
 	result := s.db.Exec(
 		fmt.Sprintf("UPDATE %s SET %s = ?, %s = ?, updated_at = ? WHERE id = ? AND account_id = ?", cfg.table, labelCol, nameCol),
 		val, val, time.Now(), id, accountID,
@@ -183,6 +192,10 @@ func (s *PersonalizeService) Delete(accountID, entity string, id uint) error {
 
 	if entity == "task-statuses" {
 		return s.deleteTaskStatus(accountID, id)
+	}
+
+	if entity == "currencies" {
+		return ErrCurrenciesNotEditable
 	}
 
 	result := s.db.Exec(


### PR DESCRIPTION
Closes #238

## Summary / 概述

Imported reminders never triggered notifications; currency personalize CRUD returned 500.

导入的提醒从未触发通知；货币个性化设置增删改返回 500。

## Changes / 变更

- **B3 — Imported reminders are never scheduled**: `MonicaImportService.importReminders` now calls `scheduleReminderForVaultUsers` right after creating each reminder (with the existing import-tolerant error accumulation), so imported one-time/recurring reminders enter `ContactReminderScheduled` and the minute cron delivers them like normally created ones (修复前 Monica 导入的提醒永不触发通知).
- **B5 — Special dates have no reminder field**: confirmed `MonicaSpecialDate` carries no reminder data in the upstream 4.x export, so creating only the important date is correct; the real gap was B3 (无字段可导入，非问题).
- **B4 — Currencies personalize 500**: create/update/delete on `currencies` now return the new sentinel `ErrCurrenciesNotEditable`, mapped to a clear 400 Bad Request instead of an internal error (修复前 500；货币是只读清单，由 SeedCurrencies 与专用 API 管理).

## Verification / 验证

- Go: `go build ./...` + `go vet ./...` clean; full service + handler test suites pass on Linux (cgo/SQLite).
- See https://github.com/naiba/bonds/issues/238#issuecomment-5331454456 for the B5 data-model finding.