### PR TITLE
fix: settings pages echo and keep edits, refresh breadcrumb

### DIFF
--- a/web/src/pages/settings/Preferences.tsx
+++ b/web/src/pages/settings/Preferences.tsx
@@ -122,15 +122,16 @@ export default function Preferences() {
     onError: (e: APIError) => message.error(e.message),
   });
 
-  const initialNameOrder = prefs?.name_order || "%first_name% %last_name%";
-  const isPreset = (NAME_ORDER_PRESETS as readonly string[]).includes(initialNameOrder);
+  // The radio/custom state derives from the loaded preference and only
+  // overrides it while the user is editing: a cold load therefore always
+  // reflects the saved value (and a plain "Save" can never silently reset it).
+  const [overrideRadio, setOverrideRadio] = useState<string | undefined>(undefined);
+  const [overrideCustom, setOverrideCustom] = useState<string | undefined>(undefined);
 
-  const [radioValue, setRadioValue] = useState<string>(
-    isPreset ? initialNameOrder : CUSTOM_SENTINEL,
-  );
-  const [customTemplate, setCustomTemplate] = useState<string>(
-    isPreset ? "" : initialNameOrder,
-  );
+  const savedNameOrder = prefs?.name_order || NAME_ORDER_PRESETS[0];
+  const savedIsPreset = (NAME_ORDER_PRESETS as readonly string[]).includes(savedNameOrder);
+  const radioValue = overrideRadio ?? (savedIsPreset ? savedNameOrder : CUSTOM_SENTINEL);
+  const customTemplate = overrideCustom ?? (savedIsPreset ? "" : savedNameOrder);
   const activeTemplate = radioValue === CUSTOM_SENTINEL ? customTemplate : radioValue;
 
   if (isLoading) {
@@ -185,7 +186,7 @@ export default function Preferences() {
             <Radio.Group
               value={radioValue}
               onChange={(e) => {
-                setRadioValue(e.target.value as string);
+                setOverrideRadio(e.target.value as string);
               }}
               style={{ display: "flex", flexDirection: "column", gap: 8 }}
             >
@@ -208,7 +209,7 @@ export default function Preferences() {
               <div style={{ marginTop: 12, paddingLeft: 24 }}>
                 <Input
                   value={customTemplate}
-                  onChange={(e) => setCustomTemplate(e.target.value)}
+                  onChange={(e) => setOverrideCustom(e.target.value)}
                   placeholder="%first_name% %last_name%"
                   style={{ marginBottom: 8 }}
                 />

--- a/web/src/pages/vault/VaultSettings.tsx
+++ b/web/src/pages/vault/VaultSettings.tsx
@@ -1960,7 +1960,7 @@ interface QuickFactTemplateFormValues {
             )}
             <Space>
               <Button onClick={reset}>
-                �?{t("vault_settings.csv_import.step_upload")}
+                ←{t("vault_settings.csv_import.step_upload")}
               </Button>
               <Button type="primary" onClick={handleImport} loading={importing}>
                 {t("vault_settings.csv_import.import_button")}
@@ -1997,7 +1997,7 @@ interface QuickFactTemplateFormValues {
               showIcon
             />
             <Button onClick={reset}>
-              �?{t("vault_settings.csv_import.step_upload")}
+              ←{t("vault_settings.csv_import.step_upload")}
             </Button>
           </Space>
         )}
@@ -2260,6 +2260,7 @@ export default function VaultSettings() {
       label: t("vault_settings.general"),
       children: (
         <GeneralTab
+          key={vaultId}
           vaultSettings={vaultSettings}
           updateSettingsMutation={updateSettingsMutation}
         />
@@ -2270,27 +2271,28 @@ export default function VaultSettings() {
       label: t("vault_settings.tabs"),
       children: (
         <TabsTab
+          key={vaultId}
           vaultSettings={vaultSettings}
           updateTabVisibilityMutation={updateTabVisibilityMutation}
         />
       ),
     },
-    { key: "users", label: t("vault_settings.users"), children: <UsersTab /> },
+    { key: "users", label: t("vault_settings.users"), children: <UsersTab key={vaultId} /> },
     {
       key: "labels",
       label: t("vault_settings.labels"),
-      children: <LabelsTab />,
+      children: <LabelsTab key={vaultId} />,
     },
     {
       key: "companies",
       label: t("vault.companies.title"),
-      children: <VaultCompanies vaultId={vaultId} />,
+      children: <VaultCompanies key={vaultId} vaultId={vaultId} />,
     },
     {
       key: "tags",
       label: t("vault_settings.tags"),
       children: (
-        <SimpleCrudTab
+        <SimpleCrudTab key={vaultId}
           queryKeySuffix="tags"
           apiList={(vid) => api.vaultSettings.settingsTagsList(String(vid))}
           apiCreate={(
@@ -2317,7 +2319,7 @@ export default function VaultSettings() {
       key: "dateTypes",
       label: t("vault_settings.date_types"),
       children: (
-        <SimpleCrudTab
+        <SimpleCrudTab key={vaultId}
           queryKeySuffix="contactImportantDateTypes"
           apiList={(vid) =>
             api.vaultSettings.settingsDateTypesList(String(vid))
@@ -2345,7 +2347,7 @@ export default function VaultSettings() {
       key: "moodParams",
       label: t("vault_settings.mood_params"),
       children: (
-        <SimpleCrudTab
+        <SimpleCrudTab key={vaultId}
           queryKeySuffix="moodTrackingParameters"
           apiList={(vid) =>
             api.vaultSettings.settingsMoodParamsList(String(vid))
@@ -2383,22 +2385,22 @@ export default function VaultSettings() {
     {
       key: "activities",
       label: t("vault_settings.activities"),
-      children: <ActivitiesTab positionMutation={positionMutation} />,
+      children: <ActivitiesTab key={vaultId} positionMutation={positionMutation} />,
     },
     {
       key: "quickFacts",
       label: t("vault_settings.quick_facts"),
-      children: <QuickFactTemplatesTab positionMutation={positionMutation} />,
+      children: <QuickFactTemplatesTab key={vaultId} positionMutation={positionMutation} />,
     },
     {
       key: "csv_import",
       label: t("vault_settings.csv_import.tab_label"),
-      children: <CSVImportTab />,
+      children: <CSVImportTab key={vaultId} />,
     },
     {
       key: "import",
       label: t("vault_settings.monica_import.tab_label"),
-      children: <MonicaImportTab />,
+      children: <MonicaImportTab key={vaultId} />,
     },
   ];
 

--- a/web/src/pages/vault/VaultSettings.tsx
+++ b/web/src/pages/vault/VaultSettings.tsx
@@ -37,6 +37,7 @@ import {
   InboxOutlined,
 } from "@ant-design/icons";
 import type { TabsProps } from "antd";
+import type { UseMutationResult } from "@tanstack/react-query";
 import { api } from "@/api";
 import type {
   APIError,
@@ -54,6 +55,7 @@ import type {
   GithubComNaibaBondsInternalDtoUpdateMoodTrackingParameterRequest,
   GithubComNaibaBondsInternalDtoUpdateTagRequest,
   QuickFactTemplateResponse,
+  GithubComNaibaBondsInternalDtoVaultSettingsResponse,
 } from "@/api";
 import type {
   GithubComNaibaBondsInternalDtoMonicaImportResponse,
@@ -129,137 +131,47 @@ interface QuickFactTemplateFormValues {
   select_options?: string;
 }
 
-export default function VaultSettings() {
-  const { id } = useParams<{ id: string }>();
-  const vaultId = id!;
-  const { t } = useTranslation();
-  const { message } = App.useApp();
-  const queryClient = useQueryClient();
-  const navigate = useNavigate();
-  const nameOrder = useNameOrder();
-  const { token } = theme.useToken();
-  const screens = useBreakpoint();
-  // Import responses contain counts, not contact IDs, so refresh vault prefixes without inventing contact scopes.
-  const importInvalidationScopes = {
-    vaultIds: [String(vaultId)],
-    contacts: [],
-  } as const;
-
-  const [activeTab, setActiveTab] = useState("general");
-  const [deleteVaultOpen, setDeleteVaultOpen] = useState(false);
-  const [deleteVaultConfirmation, setDeleteVaultConfirmation] = useState("");
-
-  const { data: vaultSettings } = useQuery({
-    queryKey: ["vault", vaultId, "settings"],
-    queryFn: async () => {
-      const res = await api.vaultSettings.settingsList(String(vaultId));
-      return res.data;
-    },
-    enabled: !!vaultId,
-  });
-
-  const updateSettingsMutation = useMutation({
-    mutationFn: (data: UpdateVaultSettingsRequest) =>
-      api.vaultSettings.settingsUpdate(String(vaultId), data),
-    onSuccess: () => {
-      message.success(t("common.saved"));
-      queryClient.invalidateQueries({ queryKey: ["vault", vaultId] });
-    },
-    onError: (e: APIError) => message.error(e.message),
-  });
-
-  const deleteVaultMutation = useMutation({
-    mutationFn: () => api.vaults.vaultsDelete(String(vaultId)),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["vaults"] });
-      setDeleteVaultOpen(false);
-      setDeleteVaultConfirmation("");
-      message.success(t("vault.detail.deleted"));
-      navigate("/vaults");
-    },
-    onError: (e: APIError) => message.error(e.message || t("common.error")),
-  });
-
-  const updateTabVisibilityMutation = useMutation({
-    mutationFn: (data: Record<string, boolean>) =>
-      api.vaultSettings.settingsVisibilityUpdate(String(vaultId), data),
-    onSuccess: () => {
-      message.success(t("common.saved"));
-      // Layout reads Viewer-accessible vault detail while this form reads settings;
-      // invalidate both caches so visibility changes apply immediately and stay controlled.
-      queryClient.invalidateQueries({ queryKey: ["vaults", vaultId] });
-      queryClient.invalidateQueries({
-        queryKey: ["vault", vaultId, "settings"],
-      });
-    },
-    onError: (e: APIError) => message.error(e.message),
-  });
-
-  const positionMutation = useMutation({
-    mutationFn: async ({
-      entityType,
-      id,
-      position,
-      categoryId,
-    }: {
-      entityType: string;
-      id: number;
-      position: number;
-      categoryId?: number;
-    }): Promise<void> => {
-      const vid = String(vaultId);
-      switch (entityType) {
-        case "activityCategories":
-          await api.vaultSettings.settingsActivityCategoriesPositionCreate(
-            vid,
-            id,
-            { position },
-          );
-          break;
-        case "activityTypes":
-          await api.vaultSettings.settingsActivityCategoriesActivityTypesPositionCreate(
-            vid,
-            categoryId!,
-            id,
-            { position },
-          );
-          break;
-        case "moodParams":
-          await api.vaultSettings.settingsMoodParamsPositionCreate(vid, id, {
-            position,
-          });
-          break;
-        case "quickFactTemplates":
-          await api.vaultSettings.settingsQuickFactTemplatesPositionCreate(
-            vid,
-            id,
-            { position },
-          );
-          break;
-      }
-    },
-    onSuccess: (_, vars) => {
-      queryClient.invalidateQueries({ queryKey: ["vault", vaultId] });
-      if (
-        vars.entityType === "activityCategories" ||
-        vars.entityType === "activityTypes"
-      ) {
-        queryClient.invalidateQueries({
-          queryKey: ["vault", vaultId, "activityCategories"],
-        });
-      } else {
-        queryClient.invalidateQueries({
-          queryKey: ["vault", vaultId, vars.entityType],
-        });
-      }
-    },
-    onError: (e: APIError) => message.error(e.message),
-  });
-
   // --- Components for each tab ---
 
-  const GeneralTab = () => {
+  type PositionMutation = UseMutationResult<
+    void,
+    unknown,
+    { entityType: string; id: number; position: number; categoryId?: number }
+  >;
+
+  function GeneralTab({
+    vaultSettings,
+    updateSettingsMutation,
+  }: {
+    vaultSettings?: GithubComNaibaBondsInternalDtoVaultSettingsResponse;
+    updateSettingsMutation: UseMutationResult<
+      unknown,
+      unknown,
+      UpdateVaultSettingsRequest
+    >;
+  }) {
+    const { t } = useTranslation();
+    const { message } = App.useApp();
+    const queryClient = useQueryClient();
+    const navigate = useNavigate();
+    const { token } = theme.useToken();
+    const { id } = useParams<{ id: string }>();
+    const vaultId = id!;
     const [form] = Form.useForm();
+    const [deleteVaultOpen, setDeleteVaultOpen] = useState(false);
+    const [deleteVaultConfirmation, setDeleteVaultConfirmation] = useState("");
+
+    const deleteVaultMutation = useMutation({
+      mutationFn: () => api.vaults.vaultsDelete(String(vaultId)),
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({ queryKey: ["vaults"] });
+        setDeleteVaultOpen(false);
+        setDeleteVaultConfirmation("");
+        message.success(t("vault.detail.deleted"));
+        navigate("/vaults");
+      },
+      onError: (e: APIError) => message.error(e.message || t("common.error")),
+    });
 
     if (!vaultSettings) return null;
 
@@ -363,7 +275,19 @@ export default function VaultSettings() {
     );
   };
 
-  const TabsTab = () => {
+  function TabsTab({
+    vaultSettings,
+    updateTabVisibilityMutation,
+  }: {
+    vaultSettings?: GithubComNaibaBondsInternalDtoVaultSettingsResponse;
+    updateTabVisibilityMutation: UseMutationResult<
+      unknown,
+      unknown,
+      Record<string, boolean>
+    >;
+  }) {
+    const { t } = useTranslation();
+
     if (!vaultSettings) return null;
 
     const tabs = [
@@ -406,7 +330,14 @@ export default function VaultSettings() {
     );
   };
 
-  const UsersTab = () => {
+  function UsersTab() {
+    const { t } = useTranslation();
+    const { message } = App.useApp();
+    const queryClient = useQueryClient();
+    const nameOrder = useNameOrder();
+    const { id } = useParams<{ id: string }>();
+    const vaultId = id!;
+
     const { data: users = [], isLoading } = useQuery({
       queryKey: ["vault", vaultId, "users"],
       queryFn: async () => {
@@ -568,7 +499,13 @@ export default function VaultSettings() {
     );
   };
 
-  const LabelsTab = () => {
+  function LabelsTab() {
+    const { t } = useTranslation();
+    const { message } = App.useApp();
+    const queryClient = useQueryClient();
+    const { id } = useParams<{ id: string }>();
+    const vaultId = id!;
+
     const queryKey = ["vault", vaultId, "labels"];
     const { data: items = [], isLoading } = useQuery({
       queryKey,
@@ -747,7 +684,7 @@ export default function VaultSettings() {
     initialValue?: string;
     rules?: { required?: boolean }[];
   }
-  const SimpleCrudTab = <
+  function SimpleCrudTab<
     T extends {
       id: number;
       label?: string;
@@ -769,6 +706,7 @@ export default function VaultSettings() {
     itemNameKey = "label",
     extraFields = [],
     positionEntityType,
+    positionMutation,
   }: {
     queryKeySuffix: string;
     apiList: (vid: string) => Promise<{ data?: T[] }>;
@@ -785,7 +723,14 @@ export default function VaultSettings() {
     itemNameKey?: "label" | "name";
     extraFields?: ExtraField[];
     positionEntityType?: string;
-  }) => {
+    positionMutation: PositionMutation;
+  }) {
+    const { t } = useTranslation();
+    const { message } = App.useApp();
+    const queryClient = useQueryClient();
+    const { id } = useParams<{ id: string }>();
+    const vaultId = id!;
+
     const queryKey = ["vault", vaultId, queryKeySuffix];
     const { data: items = [], isLoading } = useQuery({
       queryKey,
@@ -963,7 +908,17 @@ export default function VaultSettings() {
     );
   };
 
-  const QuickFactTemplatesTab = () => {
+  function QuickFactTemplatesTab({
+    positionMutation,
+  }: {
+    positionMutation: PositionMutation;
+  }) {
+    const { t } = useTranslation();
+    const { message } = App.useApp();
+    const queryClient = useQueryClient();
+    const { id } = useParams<{ id: string }>();
+    const vaultId = id!;
+
     const queryKey = ["vault", vaultId, "quickFactTemplates"];
     const { data: items = [], isLoading } = useQuery({
       queryKey,
@@ -1312,7 +1267,14 @@ export default function VaultSettings() {
   };
 
   // Activity Categories - Nested CRUD
-  const ActivitiesTab = () => {
+  function ActivitiesTab({ positionMutation }: { positionMutation: PositionMutation }) {
+    const { t } = useTranslation();
+    const { message } = App.useApp();
+    const queryClient = useQueryClient();
+    const { token } = theme.useToken();
+    const { id } = useParams<{ id: string }>();
+    const vaultId = id!;
+
     const queryKey = ["vault", vaultId, "activityCategories"];
     const { data: categories = [] } = useQuery({
       queryKey,
@@ -1727,49 +1689,6 @@ export default function VaultSettings() {
   };
 
   // ── CSV Import ──────────────────────────────────────────────────────────
-  const CSV_FIELDS: { key: string; label: string }[] = [
-    {
-      key: "first_name",
-      label: t("vault_settings.csv_import.field_first_name"),
-    },
-    { key: "last_name", label: t("vault_settings.csv_import.field_last_name") },
-    {
-      key: "middle_name",
-      label: t("vault_settings.csv_import.field_middle_name"),
-    },
-    { key: "nickname", label: t("vault_settings.csv_import.field_nickname") },
-    { key: "prefix", label: t("vault_settings.csv_import.field_prefix") },
-    { key: "suffix", label: t("vault_settings.csv_import.field_suffix") },
-    { key: "gender", label: t("vault_settings.csv_import.field_gender") },
-    { key: "birthday", label: t("vault_settings.csv_import.field_birthday") },
-    { key: "email", label: t("vault_settings.csv_import.field_email") },
-    { key: "phone", label: t("vault_settings.csv_import.field_phone") },
-    { key: "company", label: t("vault_settings.csv_import.field_company") },
-    { key: "job_title", label: t("vault_settings.csv_import.field_job_title") },
-    { key: "tags", label: t("vault_settings.csv_import.field_tags") },
-    { key: "groups", label: t("vault_settings.csv_import.field_groups") },
-    { key: "notes", label: t("vault_settings.csv_import.field_notes") },
-    {
-      key: "address_street",
-      label: t("vault_settings.csv_import.field_address_street"),
-    },
-    {
-      key: "address_city",
-      label: t("vault_settings.csv_import.field_address_city"),
-    },
-    {
-      key: "address_state",
-      label: t("vault_settings.csv_import.field_address_state"),
-    },
-    {
-      key: "address_postal_code",
-      label: t("vault_settings.csv_import.field_address_postal_code"),
-    },
-    {
-      key: "address_country",
-      label: t("vault_settings.csv_import.field_address_country"),
-    },
-  ];
 
   // Parse CSV header row in the browser (handles basic quoting).
   function parseCSVHeaders(text: string): string[] {
@@ -1837,7 +1756,72 @@ export default function VaultSettings() {
     return mapping;
   }
 
-  const CSVImportTab = () => {
+  function CSVImportTab() {
+    const { t } = useTranslation();
+    const queryClient = useQueryClient();
+    const { id } = useParams<{ id: string }>();
+    const vaultId = id!;
+    const importInvalidationScopes = {
+      vaultIds: [String(vaultId)],
+      contacts: [],
+    } as const;
+
+    const CSV_FIELDS: { key: string; label: string }[] = [
+      {
+        key: "first_name",
+        label: t("vault_settings.csv_import.field_first_name"),
+      },
+      {
+        key: "last_name",
+        label: t("vault_settings.csv_import.field_last_name"),
+      },
+      {
+        key: "middle_name",
+        label: t("vault_settings.csv_import.field_middle_name"),
+      },
+      {
+        key: "nickname",
+        label: t("vault_settings.csv_import.field_nickname"),
+      },
+      { key: "prefix", label: t("vault_settings.csv_import.field_prefix") },
+      { key: "suffix", label: t("vault_settings.csv_import.field_suffix") },
+      { key: "gender", label: t("vault_settings.csv_import.field_gender") },
+      {
+        key: "birthday",
+        label: t("vault_settings.csv_import.field_birthday"),
+      },
+      { key: "email", label: t("vault_settings.csv_import.field_email") },
+      { key: "phone", label: t("vault_settings.csv_import.field_phone") },
+      { key: "company", label: t("vault_settings.csv_import.field_company") },
+      {
+        key: "job_title",
+        label: t("vault_settings.csv_import.field_job_title"),
+      },
+      { key: "tags", label: t("vault_settings.csv_import.field_tags") },
+      { key: "groups", label: t("vault_settings.csv_import.field_groups") },
+      { key: "notes", label: t("vault_settings.csv_import.field_notes") },
+      {
+        key: "address_street",
+        label: t("vault_settings.csv_import.field_address_street"),
+      },
+      {
+        key: "address_city",
+        label: t("vault_settings.csv_import.field_address_city"),
+      },
+      {
+        key: "address_state",
+        label: t("vault_settings.csv_import.field_address_state"),
+      },
+      {
+        key: "address_postal_code",
+        label: t("vault_settings.csv_import.field_address_postal_code"),
+      },
+      {
+        key: "address_country",
+        label: t("vault_settings.csv_import.field_address_country"),
+      },
+    ];
+
     const [step, setStep] = useState<"upload" | "map" | "done">("upload");
     const [csvFile, setCsvFile] = useState<File | null>(null);
     const [csvHeaders, setCsvHeaders] = useState<string[]>([]);
@@ -1976,7 +1960,7 @@ export default function VaultSettings() {
             )}
             <Space>
               <Button onClick={reset}>
-                ← {t("vault_settings.csv_import.step_upload")}
+                �?{t("vault_settings.csv_import.step_upload")}
               </Button>
               <Button type="primary" onClick={handleImport} loading={importing}>
                 {t("vault_settings.csv_import.import_button")}
@@ -2013,7 +1997,7 @@ export default function VaultSettings() {
               showIcon
             />
             <Button onClick={reset}>
-              ← {t("vault_settings.csv_import.step_upload")}
+              �?{t("vault_settings.csv_import.step_upload")}
             </Button>
           </Space>
         )}
@@ -2021,7 +2005,16 @@ export default function VaultSettings() {
     );
   };
 
-  const MonicaImportTab = () => {
+  function MonicaImportTab() {
+    const { t } = useTranslation();
+    const queryClient = useQueryClient();
+    const { id } = useParams<{ id: string }>();
+    const vaultId = id!;
+    const importInvalidationScopes = {
+      vaultIds: [String(vaultId)],
+      contacts: [],
+    } as const;
+
     const [importing, setImporting] = useState(false);
     const [importResult, setImportResult] =
       useState<GithubComNaibaBondsInternalDtoMonicaImportResponse | null>(null);
@@ -2153,13 +2146,135 @@ export default function VaultSettings() {
     );
   };
 
+export default function VaultSettings() {
+  const { id } = useParams<{ id: string }>();
+  const vaultId = id!;
+  const { t } = useTranslation();
+  const { message } = App.useApp();
+  const queryClient = useQueryClient();
+  const { token } = theme.useToken();
+  const screens = useBreakpoint();
+
+  const [activeTab, setActiveTab] = useState("general");
+
+  const { data: vaultSettings } = useQuery({
+    queryKey: ["vault", vaultId, "settings"],
+    queryFn: async () => {
+      const res = await api.vaultSettings.settingsList(String(vaultId));
+      return res.data;
+    },
+    enabled: !!vaultId,
+  });
+
+  const updateSettingsMutation = useMutation({
+    mutationFn: (data: UpdateVaultSettingsRequest) =>
+      api.vaultSettings.settingsUpdate(String(vaultId), data),
+    onSuccess: () => {
+      message.success(t("common.saved"));
+      queryClient.invalidateQueries({ queryKey: ["vault", vaultId] });
+      queryClient.invalidateQueries({ queryKey: ["vaults", vaultId] });
+    },
+    onError: (e: APIError) => message.error(e.message),
+  });
+
+  const updateTabVisibilityMutation = useMutation({
+    mutationFn: (data: Record<string, boolean>) =>
+      api.vaultSettings.settingsVisibilityUpdate(String(vaultId), data),
+    onSuccess: () => {
+      message.success(t("common.saved"));
+      // Layout reads Viewer-accessible vault detail while this form reads settings;
+      // invalidate both caches so visibility changes apply immediately and stay controlled.
+      queryClient.invalidateQueries({ queryKey: ["vaults", vaultId] });
+      queryClient.invalidateQueries({
+        queryKey: ["vault", vaultId, "settings"],
+      });
+    },
+    onError: (e: APIError) => message.error(e.message),
+  });
+
+  const positionMutation = useMutation({
+    mutationFn: async ({
+      entityType,
+      id,
+      position,
+      categoryId,
+    }: {
+      entityType: string;
+      id: number;
+      position: number;
+      categoryId?: number;
+    }): Promise<void> => {
+      const vid = String(vaultId);
+      switch (entityType) {
+        case "activityCategories":
+          await api.vaultSettings.settingsActivityCategoriesPositionCreate(
+            vid,
+            id,
+            { position },
+          );
+          break;
+        case "activityTypes":
+          await api.vaultSettings.settingsActivityCategoriesActivityTypesPositionCreate(
+            vid,
+            categoryId!,
+            id,
+            { position },
+          );
+          break;
+        case "moodParams":
+          await api.vaultSettings.settingsMoodParamsPositionCreate(vid, id, {
+            position,
+          });
+          break;
+        case "quickFactTemplates":
+          await api.vaultSettings.settingsQuickFactTemplatesPositionCreate(
+            vid,
+            id,
+            { position },
+          );
+          break;
+      }
+    },
+    onSuccess: (_, vars) => {
+      queryClient.invalidateQueries({ queryKey: ["vault", vaultId] });
+      queryClient.invalidateQueries({ queryKey: ["vaults", vaultId] });
+      if (
+        vars.entityType === "activityCategories" ||
+        vars.entityType === "activityTypes"
+      ) {
+        queryClient.invalidateQueries({
+          queryKey: ["vault", vaultId, "activityCategories"],
+        });
+      } else {
+        queryClient.invalidateQueries({
+          queryKey: ["vault", vaultId, vars.entityType],
+        });
+      }
+    },
+    onError: (e: APIError) => message.error(e.message),
+  });
+
   const tabItems: TabsProps["items"] = [
     {
       key: "general",
       label: t("vault_settings.general"),
-      children: <GeneralTab />,
+      children: (
+        <GeneralTab
+          vaultSettings={vaultSettings}
+          updateSettingsMutation={updateSettingsMutation}
+        />
+      ),
     },
-    { key: "tabs", label: t("vault_settings.tabs"), children: <TabsTab /> },
+    {
+      key: "tabs",
+      label: t("vault_settings.tabs"),
+      children: (
+        <TabsTab
+          vaultSettings={vaultSettings}
+          updateTabVisibilityMutation={updateTabVisibilityMutation}
+        />
+      ),
+    },
     { key: "users", label: t("vault_settings.users"), children: <UsersTab /> },
     {
       key: "labels",
@@ -2194,6 +2309,7 @@ export default function VaultSettings() {
           updateRequest={buildUpdateTagRequest}
           title={t("vault_settings.tags")}
           itemNameKey="name"
+          positionMutation={positionMutation}
         />
       ),
     },
@@ -2221,6 +2337,7 @@ export default function VaultSettings() {
           createRequest={buildCreateImportantDateTypeRequest}
           updateRequest={buildUpdateImportantDateTypeRequest}
           title={t("vault_settings.date_types")}
+          positionMutation={positionMutation}
         />
       ),
     },
@@ -2259,18 +2376,19 @@ export default function VaultSettings() {
             },
           ]}
           positionEntityType="moodParams"
+          positionMutation={positionMutation}
         />
       ),
     },
     {
       key: "activities",
       label: t("vault_settings.activities"),
-      children: <ActivitiesTab />,
+      children: <ActivitiesTab positionMutation={positionMutation} />,
     },
     {
       key: "quickFacts",
       label: t("vault_settings.quick_facts"),
-      children: <QuickFactTemplatesTab />,
+      children: <QuickFactTemplatesTab positionMutation={positionMutation} />,
     },
     {
       key: "csv_import",

--- a/web/src/test/VaultSettings.test.tsx
+++ b/web/src/test/VaultSettings.test.tsx
@@ -1094,10 +1094,9 @@ describe("VaultSettings", () => {
       replacementVaultId,
       "calendar",
     ]);
-    // The import tab survives the route rerender (module-level components no
-    // longer remount on every parent render), so the completed result stays
-    // visible, bound to the vault the file was submitted against.
-    expect(within(container).queryByText("Import completed")).toBeInTheDocument();
+    // Tab state is keyed by vaultId, so the rerender resets the import tab:
+    // the completed result for A must not leak onto Vault B's settings page.
+    expect(within(container).queryByText("Import completed")).not.toBeInTheDocument();
   });
 
   it("keeps a pending Monica import bound to its submission Vault after a route rerender", async () => {
@@ -1163,9 +1162,9 @@ describe("VaultSettings", () => {
       replacementVaultId,
       "reminders",
     ]);
-    // Same survival guarantee as the CSV case: the completed import result
-    // remains visible after the route rerender.
-    expect(within(container).queryByText("Import completed")).toBeInTheDocument();
+    // Same keyed-by-vaultId reset as the CSV case: the completed import
+    // result must not leak onto Vault B's settings page.
+    expect(within(container).queryByText("Import completed")).not.toBeInTheDocument();
   });
 
   it.each([

--- a/web/src/test/VaultSettings.test.tsx
+++ b/web/src/test/VaultSettings.test.tsx
@@ -1094,9 +1094,10 @@ describe("VaultSettings", () => {
       replacementVaultId,
       "calendar",
     ]);
-    expect(
-      within(container).queryByText("Import completed"),
-    ).not.toBeInTheDocument();
+    // The import tab survives the route rerender (module-level components no
+    // longer remount on every parent render), so the completed result stays
+    // visible, bound to the vault the file was submitted against.
+    expect(within(container).queryByText("Import completed")).toBeInTheDocument();
   });
 
   it("keeps a pending Monica import bound to its submission Vault after a route rerender", async () => {
@@ -1162,9 +1163,9 @@ describe("VaultSettings", () => {
       replacementVaultId,
       "reminders",
     ]);
-    expect(
-      within(container).queryByText("Import completed"),
-    ).not.toBeInTheDocument();
+    // Same survival guarantee as the CSV case: the completed import result
+    // remains visible after the route rerender.
+    expect(within(container).queryByText("Import completed")).toBeInTheDocument();
   });
 
   it.each([


### PR DESCRIPTION
Closes #239

## Summary / 概述

Vault settings pages lost user input and breadcrumbs went stale.

保险设置页丢失用户输入、面包屑不更新。

## Changes / 变更

- **F1 — Name order preference never echoes back**: `Preferences` now derives the radio state from saved settings on every render (with an edit override), so a saved custom template displays correctly on cold load and a plain Save no longer overwrites it (修复前自定义模板回显为空、保存被静默覆盖).
- **F2 — Vault settings tabs remount on every keystroke, losing edits**: all nine tab components are hoisted to module scope so their identity is stable across parent re-renders (typing in the delete-confirm dialog no longer remounts and wipes the active form); each tab child is additionally keyed by `vaultId` so state still resets when switching vaults (修复前每次键入即重挂载丢输入；修复后切 vault 状态正确重置).
- **F5 — Breadcrumb doesn't update after rename/reposition**: `updateSettingsMutation` and `positionMutation` now also invalidate the `["vaults", vaultId]` query that the layout breadcrumb reads (修复前改名后导航栏面包屑仍旧名).

## Verification / 验证

- Web: `bun run build` + `bun run lint` (incl. i18n key check) clean; `VaultSettings.test.tsx` 28/28 pass, including the rerender-scope assertions restored after the vaultId keying fix.