### PR TITLE
fix: dark-mode graph colors, cancel/close form resets, responsive drawer widths

### DIFF
--- a/web/src/components/NetworkGraph.tsx
+++ b/web/src/components/NetworkGraph.tsx
@@ -120,13 +120,11 @@ export default function NetworkGraph({
     svg.selectAll("*").remove();
     svg.attr("viewBox", `0 0 ${width} ${height}`);
 
-    const isDark =
-      document.documentElement.getAttribute("data-theme") === "dark";
-    const textColor = isDark ? "#e5e7eb" : "#374151";
-    const edgeColor = isDark ? "#4b5563" : "#d1d5db";
+    const textColor = token.colorText;
+    const edgeColor = token.colorBorder;
     const centerColor = token.colorPrimary;
-    const nodeColor = isDark ? "#6b7280" : "#9ca3af";
-    const hoverEdgeColor = isDark ? "#93c5fd" : "#3b82f6";
+    const nodeColor = token.colorTextTertiary;
+    const hoverEdgeColor = token.colorInfo;
 
     const nodeRadius = isMobile ? 6 : 8;
     const centerNodeRadius = isMobile ? 9 : 12;
@@ -341,7 +339,11 @@ export default function NetworkGraph({
     };
   }, [
     graphData,
+    token.colorText,
+    token.colorBorder,
     token.colorPrimary,
+    token.colorTextTertiary,
+    token.colorInfo,
     navigate,
     vaultId,
     getNodeId,
@@ -352,11 +354,9 @@ export default function NetworkGraph({
     if (!svgRef.current || !graphData) return;
     const svg = d3.select(svgRef.current);
 
-    const isDark =
-      document.documentElement.getAttribute("data-theme") === "dark";
-    const edgeColor = isDark ? "#4b5563" : "#d1d5db";
+    const edgeColor = token.colorBorder;
     const centerColor = token.colorPrimary;
-    const nodeColor = isDark ? "#6b7280" : "#9ca3af";
+    const nodeColor = token.colorTextTertiary;
     const selectedColor = "#f59e0b";
     const highlightEdgeColor = "#ef4444";
 
@@ -404,7 +404,15 @@ export default function NetworkGraph({
         .attr("stroke-opacity", 0.3)
         .attr("stroke-width", 1.5);
     }
-  }, [selectedNodes, kinship, graphData, token.colorPrimary, getNodeId]);
+  }, [
+    selectedNodes,
+    kinship,
+    graphData,
+    token.colorBorder,
+    token.colorPrimary,
+    token.colorTextTertiary,
+    getNodeId,
+  ]);
 
   if (loading) {
     return (

--- a/web/src/components/NetworkGraph.tsx
+++ b/web/src/components/NetworkGraph.tsx
@@ -120,7 +120,8 @@ export default function NetworkGraph({
     svg.selectAll("*").remove();
     svg.attr("viewBox", `0 0 ${width} ${height}`);
 
-    const isDark = document.documentElement.classList.contains("dark");
+    const isDark =
+      document.documentElement.getAttribute("data-theme") === "dark";
     const textColor = isDark ? "#e5e7eb" : "#374151";
     const edgeColor = isDark ? "#4b5563" : "#d1d5db";
     const centerColor = token.colorPrimary;
@@ -351,7 +352,8 @@ export default function NetworkGraph({
     if (!svgRef.current || !graphData) return;
     const svg = d3.select(svgRef.current);
 
-    const isDark = document.documentElement.classList.contains("dark");
+    const isDark =
+      document.documentElement.getAttribute("data-theme") === "dark";
     const edgeColor = isDark ? "#4b5563" : "#d1d5db";
     const centerColor = token.colorPrimary;
     const nodeColor = isDark ? "#6b7280" : "#9ca3af";

--- a/web/src/pages/contact/ContactList.tsx
+++ b/web/src/pages/contact/ContactList.tsx
@@ -904,7 +904,12 @@ export default function ContactList() {
             />
           </Form.Item>
           <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
-            <Button onClick={() => setBulkMoveOpen(false)}>
+            <Button
+              onClick={() => {
+                setBulkMoveOpen(false);
+                bulkMoveForm.resetFields();
+              }}
+            >
               {t("common.cancel")}
             </Button>
             <Button

--- a/web/src/pages/contact/modules/ActivitiesModule.tsx
+++ b/web/src/pages/contact/modules/ActivitiesModule.tsx
@@ -236,6 +236,7 @@ export default function ActivitiesModule({
   const startCreate = () => {
     setEditing(null);
     setDescription("");
+    form.resetFields();
     form.setFieldsValue({
       start_calendar: {
         calendarType: "gregorian",
@@ -445,6 +446,9 @@ export default function ActivitiesModule({
         open={open}
         onCancel={() => {
           setOpen(false);
+          setEditing(null);
+          setDescription("");
+          form.resetFields();
           onModalClose?.();
         }}
         onOk={() => form.submit()}

--- a/web/src/pages/contact/modules/GroupsModule.tsx
+++ b/web/src/pages/contact/modules/GroupsModule.tsx
@@ -144,7 +144,10 @@ export default function GroupsModule({ vaultId, contactId }: GroupsModuleProps) 
       <Modal
         title={t("contact.detail.groups.add")}
         open={isModalOpen}
-        onCancel={() => setIsModalOpen(false)}
+        onCancel={() => {
+          setIsModalOpen(false);
+          form.resetFields();
+        }}
         footer={null}
         destroyOnClose={true}
       >
@@ -174,7 +177,14 @@ export default function GroupsModule({ vaultId, contactId }: GroupsModuleProps) 
             </Text>
           )}
           <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
-            <Button onClick={() => setIsModalOpen(false)}>{t("common.cancel")}</Button>
+            <Button
+            onClick={() => {
+              setIsModalOpen(false);
+              form.resetFields();
+            }}
+          >
+            {t("common.cancel")}
+          </Button>
             <Button
               type="primary"
               htmlType="submit"

--- a/web/src/pages/contact/modules/GroupsModule.tsx
+++ b/web/src/pages/contact/modules/GroupsModule.tsx
@@ -178,13 +178,13 @@ export default function GroupsModule({ vaultId, contactId }: GroupsModuleProps) 
           )}
           <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
             <Button
-            onClick={() => {
-              setIsModalOpen(false);
-              form.resetFields();
-            }}
-          >
-            {t("common.cancel")}
-          </Button>
+              onClick={() => {
+                setIsModalOpen(false);
+                form.resetFields();
+              }}
+            >
+              {t("common.cancel")}
+            </Button>
             <Button
               type="primary"
               htmlType="submit"

--- a/web/src/pages/contact/modules/LabelsModule.tsx
+++ b/web/src/pages/contact/modules/LabelsModule.tsx
@@ -177,7 +177,10 @@ export default function LabelsModule({ vaultId, contactId }: LabelsModuleProps) 
       <Modal
         title={t("contact.detail.labels.add")}
         open={isModalOpen}
-        onCancel={() => setIsModalOpen(false)}
+        onCancel={() => {
+          setIsModalOpen(false);
+          form.resetFields();
+        }}
         footer={null}
         destroyOnClose={true}
       >
@@ -212,7 +215,14 @@ export default function LabelsModule({ vaultId, contactId }: LabelsModuleProps) 
             </div>
           )}
           <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
-            <Button onClick={() => setIsModalOpen(false)}>{t("common.cancel")}</Button>
+            <Button
+            onClick={() => {
+              setIsModalOpen(false);
+              form.resetFields();
+            }}
+          >
+            {t("common.cancel")}
+          </Button>
             <Button 
               type="primary" 
               htmlType="submit" 

--- a/web/src/pages/contact/modules/LabelsModule.tsx
+++ b/web/src/pages/contact/modules/LabelsModule.tsx
@@ -216,13 +216,13 @@ export default function LabelsModule({ vaultId, contactId }: LabelsModuleProps) 
           )}
           <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
             <Button
-            onClick={() => {
-              setIsModalOpen(false);
-              form.resetFields();
-            }}
-          >
-            {t("common.cancel")}
-          </Button>
+              onClick={() => {
+                setIsModalOpen(false);
+                form.resetFields();
+              }}
+            >
+              {t("common.cancel")}
+            </Button>
             <Button 
               type="primary" 
               htmlType="submit" 

--- a/web/src/pages/settings/Notifications.tsx
+++ b/web/src/pages/settings/Notifications.tsx
@@ -17,6 +17,7 @@ import {
   theme,
   Drawer,
   Space,
+  Grid,
 } from "antd";
 import {
   PlusOutlined,
@@ -78,6 +79,7 @@ export default function Notifications() {
   const { message } = App.useApp();
   const { t } = useTranslation();
   const { token } = theme.useToken();
+  const screens = Grid.useBreakpoint();
   const dateFormats = useDateFormat();
   const qk = ["settings", "notifications"];
 
@@ -449,7 +451,7 @@ export default function Notifications() {
         title={t("settings.notifications.logs_title")}
         open={logsChannelId !== null}
         onClose={() => setLogsChannelId(null)}
-        width={480}
+        size={screens.md ? 480 : "100%"}
       >
         {logs.length === 0 ? (
           <Empty description={t("settings.notifications.no_logs")} />

--- a/web/src/pages/vault/DavSubscriptions.tsx
+++ b/web/src/pages/vault/DavSubscriptions.tsx
@@ -21,6 +21,7 @@ import {
   Tooltip,
   Empty,
   Card,
+  Grid,
 } from "antd";
 import {
   ArrowLeftOutlined,
@@ -77,6 +78,7 @@ export default function DavSubscriptions() {
   const { message } = App.useApp();
   const { user } = useAuth();
   const queryClient = useQueryClient();
+  const screens = Grid.useBreakpoint();
   const [form] = Form.useForm();
   const dateFormats = useDateFormat();
   const davUserPathSegment = user?.id ?? "";
@@ -554,7 +556,7 @@ export default function DavSubscriptions() {
       <Drawer
         title={`${t("vault.dav_subscriptions.sync_logs")} - ${logsSubscription?.uri ?? ""}`}
         placement="right"
-        width={700}
+        size={screens.md ? 700 : "100%"}
         open={logsDrawerOpen}
         onClose={() => {
           setLogsDrawerOpen(false);

--- a/web/src/pages/vault/DavSubscriptions.tsx
+++ b/web/src/pages/vault/DavSubscriptions.tsx
@@ -438,7 +438,7 @@ export default function DavSubscriptions() {
         onOk={handleModalOk}
         confirmLoading={createMutation.isPending || updateMutation.isPending}
         destroyOnClose
-        width={560}
+        width={screens.md ? 560 : "calc(100vw - 32px)"}
       >
         <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
           <Form.Item

--- a/web/src/pages/vault/VaultCompanies.tsx
+++ b/web/src/pages/vault/VaultCompanies.tsx
@@ -20,6 +20,7 @@ import {
   List,
   Empty,
   Popconfirm,
+  Grid,
 } from "antd";
 import {
   BankOutlined,
@@ -44,6 +45,7 @@ export default function VaultCompanies({ vaultId }: { vaultId: string }) {
   const queryClient = useQueryClient();
   const { token } = theme.useToken();
   const { message } = App.useApp();
+  const screens = Grid.useBreakpoint();
   const nameOrder = useNameOrder();
   const [form] = Form.useForm();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -314,7 +316,7 @@ export default function VaultCompanies({ vaultId }: { vaultId: string }) {
         placement="right"
         onClose={() => setSelectedCompany(null)}
         open={!!selectedCompany}
-        width={500}
+        size={screens.md ? 500 : "100%"}
       >
         {selectedCompany && (
             <>


### PR DESCRIPTION
Closes #240

## Summary / 概述

Dark-mode network graph unreadable; cancelled modals kept stale form values; drawers clipped on small screens.

暗色主题关系图谱不可读；取消弹窗残留旧表单值；窄屏抽屉被裁切。

## Changes / 变更

- **F3 — Network graph invisible in dark mode**: theme detection now reads `document.documentElement.getAttribute("data-theme")` (what `ThemeProvider` actually writes) instead of `classList.contains("dark")`, so text/edges/nodes use the correct palette when the app first loads in dark mode (修复前暗色主题下首屏关系图谱文字与连线不可见).
- **F4 — Activities modal keeps stale values after cancel**: `startCreate` and the modal `onCancel` now `resetFields()` (and clear editing state), so cancel → reopen starts empty; edit mode is unaffected (修复前取消后重新打开残留上次编辑内容).
- **F7 — Labels/Groups/Bulk-move same stale-value issue**: the same reset-on-cancel fix applied to the Labels and Groups modals and the bulk-move drawer's Cancel button (修复前同类残留).
- **F6 — Settings drawers clipped on narrow screens**: Vault Companies, Notifications and DAV Subscriptions drawers use `Grid.useBreakpoint()` so the fixed `width` becomes `100%` below the md breakpoint, matching the existing `ActivityDetail` pattern (修复前小屏右缘被裁切).

## Verification / 验证

- Web: `bun run build` + `bun run lint` clean; 52 related unit tests pass.