### PR TITLE
fix: correct ICS recurrence semantics, lunar DTSTART projection, UTC-safe activity dates

### DIFF
--- a/server/internal/services/calendar_ics.go
+++ b/server/internal/services/calendar_ics.go
@@ -306,15 +306,19 @@ func projectLunarDtStart(converter calendarPkg.Converter, origDay, origMonth, or
 	if origDay == nil || origMonth == nil {
 		return fallback
 	}
-	year := fallback.Year()
-	if origYear != nil {
-		year = *origYear
+	original := calendarPkg.DateInfo{Day: *origDay, Month: *origMonth}
+	if origYear == nil {
+		// Reminder rows created through applyCalendarFields can retain the fixed
+		// 2000 storage projection even though OriginalYear is nil. Never derive
+		// DTSTART's recurrence year from that projection; resolve the occurrence
+		// that actually lands in the current Gregorian year instead.
+		if gd, err := calendarOccurrenceInYear(converter, original, time.Now().UTC().Year()); err == nil {
+			return time.Date(gd.Year, time.Month(gd.Month), gd.Day, 0, 0, 0, 0, time.UTC)
+		}
+		return fallback
 	}
-	if gd, err := converter.ToGregorian(calendarPkg.DateInfo{
-		Day:   *origDay,
-		Month: *origMonth,
-		Year:  year,
-	}); err == nil {
+	original.Year = *origYear
+	if gd, err := converter.ToGregorian(original); err == nil {
 		return time.Date(gd.Year, time.Month(gd.Month), gd.Day, 0, 0, 0, 0, time.UTC)
 	}
 	return fallback
@@ -328,9 +332,16 @@ func emitLunarRecurrence(c *ical.Component, converter calendarPkg.Converter, ori
 	if origDay == nil || origMonth == nil {
 		return
 	}
-	const horizonYears = 10
-	startYear := dtStart.Year()
-	if origYear != nil {
+	const horizonYears = 50
+	startYear := calendarYearForGregorianDate(converter, dtStart)
+	if current, err := calendarOccurrenceInYear(converter, calendarPkg.DateInfo{
+		Day:   *origDay,
+		Month: *origMonth,
+	}, time.Now().UTC().Year()); err == nil {
+		currentDate := time.Date(current.Year, time.Month(current.Month), current.Day, 0, 0, 0, 0, time.UTC)
+		startYear = calendarYearForGregorianDate(converter, currentDate)
+	}
+	if origYear != nil && *origYear > startYear {
 		startYear = *origYear
 	}
 
@@ -354,6 +365,18 @@ func emitLunarRecurrence(c *ical.Component, converter calendarPkg.Converter, ori
 	prop.SetValueType(ical.ValueDate)
 	prop.Value = strings.Join(values, ",")
 	c.Props.Set(prop)
+}
+
+func calendarYearForGregorianDate(converter calendarPkg.Converter, date time.Time) int {
+	converted, err := converter.FromGregorian(calendarPkg.GregorianDate{
+		Day:   date.Day(),
+		Month: int(date.Month()),
+		Year:  date.Year(),
+	})
+	if err == nil && converted.Year != 0 {
+		return converted.Year
+	}
+	return date.Year()
 }
 
 func icsUID(uuid *string, kind string, id uint) string {

--- a/server/internal/services/calendar_ics.go
+++ b/server/internal/services/calendar_ics.go
@@ -155,11 +155,10 @@ func icsImportantDateEvent(d *models.ContactImportantDate, contactName string) *
 		event.Props.SetText(ical.PropDescription, desc)
 	} else {
 		setDateValue(event, ical.PropDateTimeStart, dtStart)
-		// Only year-unknown dates (e.g. birthdays that repeat every year)
-		// recur. A date recorded with a known year is a single occurrence.
-		if d.IsYearUnknown {
-			setYearlyRecurrence(event)
-		}
+		// Important dates (especially birthdays) repeat every year regardless
+		// of the stored year — the year field is only used for display, not
+		// filtering (see CalendarService.GetCalendar). Matches CalDAV export.
+		setYearlyRecurrence(event)
 	}
 
 	return event

--- a/server/internal/services/calendar_ics.go
+++ b/server/internal/services/calendar_ics.go
@@ -138,12 +138,15 @@ func icsImportantDateEvent(d *models.ContactImportantDate, contactName string) *
 
 	year, month, day := dateParts(d.Year, d.Month, d.Day)
 	dtStart := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	setDateValue(event, ical.PropDateTimeStart, dtStart)
 
 	isAlternative := d.CalendarType != "" && d.CalendarType != "gregorian" && d.OriginalMonth != nil && d.OriginalDay != nil
 	if isAlternative {
 		if converter, ok := calendarPkg.Get(calendarPkg.CalendarType(d.CalendarType)); ok {
+			dtStart = projectLunarDtStart(converter, d.OriginalDay, d.OriginalMonth, d.OriginalYear, dtStart)
+			setDateValue(event, ical.PropDateTimeStart, dtStart)
 			emitLunarRecurrence(event, converter, d.OriginalDay, d.OriginalMonth, d.OriginalYear, dtStart)
+		} else {
+			setDateValue(event, ical.PropDateTimeStart, dtStart)
 		}
 		desc := fmt.Sprintf("Calendar: %s, Original date: %d/%d", d.CalendarType, *d.OriginalMonth, *d.OriginalDay)
 		if d.OriginalYear != nil {
@@ -151,7 +154,12 @@ func icsImportantDateEvent(d *models.ContactImportantDate, contactName string) *
 		}
 		event.Props.SetText(ical.PropDescription, desc)
 	} else {
-		setYearlyRecurrence(event)
+		setDateValue(event, ical.PropDateTimeStart, dtStart)
+		// Only year-unknown dates (e.g. birthdays that repeat every year)
+		// recur. A date recorded with a known year is a single occurrence.
+		if d.IsYearUnknown {
+			setYearlyRecurrence(event)
+		}
 	}
 
 	return event
@@ -174,15 +182,29 @@ func icsReminderEvent(r *models.ContactReminder) *ical.Component {
 
 	year, month, day := dateParts(r.Year, r.Month, r.Day)
 	dtStart := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	setDateValue(event, ical.PropDateTimeStart, dtStart)
 
 	isAlternative := r.CalendarType != "" && r.CalendarType != "gregorian" && r.OriginalMonth != nil && r.OriginalDay != nil
 	if isAlternative {
 		if converter, ok := calendarPkg.Get(calendarPkg.CalendarType(r.CalendarType)); ok {
+			dtStart = projectLunarDtStart(converter, r.OriginalDay, r.OriginalMonth, r.OriginalYear, dtStart)
+			setDateValue(event, ical.PropDateTimeStart, dtStart)
 			emitLunarRecurrence(event, converter, r.OriginalDay, r.OriginalMonth, r.OriginalYear, dtStart)
+		} else {
+			setDateValue(event, ical.PropDateTimeStart, dtStart)
 		}
-	} else {
-		setYearlyRecurrence(event)
+		return event
+	}
+
+	setDateValue(event, ical.PropDateTimeStart, dtStart)
+	// Map the reminder recurrence type onto an RRULE. one_time reminders are
+	// single occurrences and get no recurrence rule at all.
+	switch r.Type {
+	case "recurring_week":
+		setRecurrence(event, "FREQ=WEEKLY", r.FrequencyNumber)
+	case "recurring_month":
+		setRecurrence(event, "FREQ=MONTHLY", r.FrequencyNumber)
+	case "recurring_year":
+		setRecurrence(event, "FREQ=YEARLY", r.FrequencyNumber)
 	}
 
 	return event
@@ -265,6 +287,38 @@ func setYearlyRecurrence(c *ical.Component) {
 	prop := ical.NewProp(ical.PropRecurrenceRule)
 	prop.Value = "FREQ=YEARLY"
 	c.Props.Set(prop)
+}
+
+func setRecurrence(c *ical.Component, freq string, frequency *int) {
+	value := freq
+	if frequency != nil && *frequency > 1 {
+		value = fmt.Sprintf("%s;INTERVAL=%d", freq, *frequency)
+	}
+	prop := ical.NewProp(ical.PropRecurrenceRule)
+	prop.Value = value
+	c.Props.Set(prop)
+}
+
+// projectLunarDtStart returns the Gregorian date of the first projected
+// occurrence. For month+day-only lunar dates (Year is nil) the Gregorian
+// projection is only valid for the current year, so the DTSTART must coincide
+// with the first RDATE instead of the stored (nil) fields.
+func projectLunarDtStart(converter calendarPkg.Converter, origDay, origMonth, origYear *int, fallback time.Time) time.Time {
+	if origDay == nil || origMonth == nil {
+		return fallback
+	}
+	year := fallback.Year()
+	if origYear != nil {
+		year = *origYear
+	}
+	if gd, err := converter.ToGregorian(calendarPkg.DateInfo{
+		Day:   *origDay,
+		Month: *origMonth,
+		Year:  year,
+	}); err == nil {
+		return time.Date(gd.Year, time.Month(gd.Month), gd.Day, 0, 0, 0, 0, time.UTC)
+	}
+	return fallback
 }
 
 // emitLunarRecurrence mirrors the CalDAV backend: non-Gregorian dates drift

--- a/server/internal/services/calendar_ics_test.go
+++ b/server/internal/services/calendar_ics_test.go
@@ -328,26 +328,33 @@ func TestExportVaultICSRecurrenceRules(t *testing.T) {
 	}
 	out := string(data)
 
-	if !strings.Contains(out, "SUMMARY:Jane - Anniversary\r\nDTSTART;VALUE=DATE:20250315\r\n") {
+	if !strings.Contains(out, "DTSTART;VALUE=DATE:20250315\r\nSUMMARY:Jane - Anniversary\r\n") {
 		t.Errorf("expected dated important date to be a single occurrence without RRULE\n---\n%s", out)
 	}
-	if strings.Contains(out, "SUMMARY:Jane - Anniversary\r\nDTSTART;VALUE=DATE:20250315\r\nRRULE") {
+	if strings.Contains(out, "DTSTART;VALUE=DATE:20250315\r\nSUMMARY:Jane - Anniversary\r\nRRULE") {
 		t.Errorf("expected dated important date to carry no RRULE\n---\n%s", out)
 	}
-	if !strings.Contains(out, "SUMMARY:Jane - Birthday\r\nDTSTART;VALUE=DATE:"+time.Now().Format("2006")+"0315\r\nRRULE:FREQ=YEARLY") {
+	if !strings.Contains(out, "DTSTART;VALUE=DATE:"+time.Now().Format("2006")+"0315\r\nRRULE:FREQ=YEARLY\r\nSUMMARY:Jane - Birthday") {
 		t.Errorf("expected year-unknown date projected onto the current year with RRULE:FREQ=YEARLY\n---\n%s", out)
 	}
-	if !strings.Contains(out, "SUMMARY:Monthly\r\nDTSTART;VALUE=DATE:20250315\r\nRRULE:FREQ=MONTHLY;INTERVAL=2") {
+	if !strings.Contains(out, "DTSTART;VALUE=DATE:"+time.Now().Format("2006")+"0315\r\nRRULE:FREQ=MONTHLY;INTERVAL=2\r\nSUMMARY:Monthly") {
 		t.Errorf("expected monthly reminder with INTERVAL=2\n---\n%s", out)
 	}
-	if !strings.Contains(out, "SUMMARY:Yearly\r\nDTSTART;VALUE=DATE:20250315\r\nRRULE:FREQ=YEARLY") {
+	if !strings.Contains(out, "DTSTART;VALUE=DATE:"+time.Now().Format("2006")+"0315\r\nRRULE:FREQ=YEARLY\r\nSUMMARY:Yearly") {
 		t.Errorf("expected yearly reminder with RRULE:FREQ=YEARLY\n---\n%s", out)
 	}
 	if !strings.Contains(out, "SUMMARY:One Off\r\n") {
 		t.Errorf("expected one_time reminder in output\n---\n%s", out)
 	}
-	if strings.Contains(out, "SUMMARY:One Off\r\nDTSTART;VALUE=DATE:20250315\r\nRRULE") {
-		t.Errorf("expected one_time reminder to carry no RRULE\n---\n%s", out)
+	idx := strings.Index(out, "SUMMARY:One Off\r\n")
+	if idx < 0 {
+		t.Errorf("expected one_time reminder in output\n---\n%s", out)
+	} else {
+		start := strings.LastIndex(out[:idx], "BEGIN:VEVENT")
+		end := strings.Index(out[idx:], "END:VEVENT")
+		if block := out[start : idx+end+len("END:VEVENT")]; strings.Contains(block, "RRULE") {
+			t.Errorf("expected one_time reminder to carry no RRULE\n---\n%s", out)
+		}
 	}
 }
 

--- a/server/internal/services/calendar_ics_test.go
+++ b/server/internal/services/calendar_ics_test.go
@@ -268,7 +268,8 @@ func TestExportVaultICSRecurrenceRules(t *testing.T) {
 		t.Fatalf("CreateContact failed: %v", err)
 	}
 
-	// A date recorded WITH a year is a single occurrence → no RRULE.
+	// A date recorded WITH a year still repeats yearly — the year is display-only
+	// (see CalendarService.GetCalendar), so the subscription must not stop at it.
 	day, month, year := 15, 3, 2025
 	if err := db.Create(&models.ContactImportantDate{
 		ContactID: contact.ID,
@@ -328,11 +329,8 @@ func TestExportVaultICSRecurrenceRules(t *testing.T) {
 	}
 	out := string(data)
 
-	if !strings.Contains(out, "DTSTART;VALUE=DATE:20250315\r\nSUMMARY:Jane - Anniversary\r\n") {
-		t.Errorf("expected dated important date to be a single occurrence without RRULE\n---\n%s", out)
-	}
-	if strings.Contains(out, "DTSTART;VALUE=DATE:20250315\r\nSUMMARY:Jane - Anniversary\r\nRRULE") {
-		t.Errorf("expected dated important date to carry no RRULE\n---\n%s", out)
+	if !strings.Contains(out, "DTSTART;VALUE=DATE:20250315\r\nRRULE:FREQ=YEARLY\r\nSUMMARY:Jane - Anniversary") {
+		t.Errorf("expected dated important date to keep yearly recurrence (year is display-only)\n---\n%s", out)
 	}
 	if !strings.Contains(out, "DTSTART;VALUE=DATE:"+time.Now().Format("2006")+"0315\r\nRRULE:FREQ=YEARLY\r\nSUMMARY:Jane - Birthday") {
 		t.Errorf("expected year-unknown date projected onto the current year with RRULE:FREQ=YEARLY\n---\n%s", out)

--- a/server/internal/services/calendar_ics_test.go
+++ b/server/internal/services/calendar_ics_test.go
@@ -242,3 +242,171 @@ func TestExportVaultICSEmpty(t *testing.T) {
 		t.Errorf("expected a valid empty VCALENDAR, got:\n%s", out)
 	}
 }
+
+func TestExportVaultICSRecurrenceRules(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	cfg := testutil.TestJWTConfig()
+	authSvc := NewAuthService(db, cfg)
+	vaultSvc := NewVaultService(db)
+
+	resp, err := authSvc.Register(dto.RegisterRequest{
+		FirstName: "Ical",
+		LastName:  "Recur",
+		Email:     "ical-recur@example.com",
+		Password:  "password123",
+	}, "en")
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	vault, err := vaultSvc.CreateVault(resp.User.AccountID, resp.User.ID, dto.CreateVaultRequest{Name: "Recur Vault"}, "en")
+	if err != nil {
+		t.Fatalf("CreateVault failed: %v", err)
+	}
+	contactSvc := NewContactService(db)
+	contact, err := contactSvc.CreateContact(vault.ID, resp.User.ID, dto.CreateContactRequest{FirstName: "Jane"})
+	if err != nil {
+		t.Fatalf("CreateContact failed: %v", err)
+	}
+
+	// A date recorded WITH a year is a single occurrence → no RRULE.
+	day, month, year := 15, 3, 2025
+	if err := db.Create(&models.ContactImportantDate{
+		ContactID: contact.ID,
+		Label:     "Anniversary",
+		Day:       &day,
+		Month:     &month,
+		Year:      &year,
+	}).Error; err != nil {
+		t.Fatalf("create dated important date failed: %v", err)
+	}
+	// A year-unknown date repeats yearly.
+	if err := db.Create(&models.ContactImportantDate{
+		ContactID:     contact.ID,
+		Label:         "Birthday",
+		Day:           &day,
+		Month:         &month,
+		IsYearUnknown: true,
+	}).Error; err != nil {
+		t.Fatalf("create year-unknown important date failed: %v", err)
+	}
+
+	// Reminders map their Type onto an RRULE; one_time gets none.
+	if err := db.Create(&models.ContactReminder{
+		ContactID: contact.ID,
+		Label:     "One Off",
+		Day:       &day,
+		Month:     &month,
+		Type:      "one_time",
+	}).Error; err != nil {
+		t.Fatalf("create one_time reminder failed: %v", err)
+	}
+	interval := 2
+	if err := db.Create(&models.ContactReminder{
+		ContactID:       contact.ID,
+		Label:           "Monthly",
+		Day:             &day,
+		Month:           &month,
+		Type:            "recurring_month",
+		FrequencyNumber: &interval,
+	}).Error; err != nil {
+		t.Fatalf("create recurring_month reminder failed: %v", err)
+	}
+	if err := db.Create(&models.ContactReminder{
+		ContactID: contact.ID,
+		Label:     "Yearly",
+		Day:       &day,
+		Month:     &month,
+		Type:      "recurring_year",
+	}).Error; err != nil {
+		t.Fatalf("create recurring_year reminder failed: %v", err)
+	}
+
+	svc := NewCalendarICSService(db)
+	data, err := svc.ExportVault(vault.ID, resp.User.ID)
+	if err != nil {
+		t.Fatalf("ExportVault failed: %v", err)
+	}
+	out := string(data)
+
+	if !strings.Contains(out, "SUMMARY:Jane - Anniversary\r\nDTSTART;VALUE=DATE:20250315\r\n") {
+		t.Errorf("expected dated important date to be a single occurrence without RRULE\n---\n%s", out)
+	}
+	if strings.Contains(out, "SUMMARY:Jane - Anniversary\r\nDTSTART;VALUE=DATE:20250315\r\nRRULE") {
+		t.Errorf("expected dated important date to carry no RRULE\n---\n%s", out)
+	}
+	if !strings.Contains(out, "SUMMARY:Jane - Birthday\r\nDTSTART;VALUE=DATE:"+time.Now().Format("2006")+"0315\r\nRRULE:FREQ=YEARLY") {
+		t.Errorf("expected year-unknown date projected onto the current year with RRULE:FREQ=YEARLY\n---\n%s", out)
+	}
+	if !strings.Contains(out, "SUMMARY:Monthly\r\nDTSTART;VALUE=DATE:20250315\r\nRRULE:FREQ=MONTHLY;INTERVAL=2") {
+		t.Errorf("expected monthly reminder with INTERVAL=2\n---\n%s", out)
+	}
+	if !strings.Contains(out, "SUMMARY:Yearly\r\nDTSTART;VALUE=DATE:20250315\r\nRRULE:FREQ=YEARLY") {
+		t.Errorf("expected yearly reminder with RRULE:FREQ=YEARLY\n---\n%s", out)
+	}
+	if !strings.Contains(out, "SUMMARY:One Off\r\n") {
+		t.Errorf("expected one_time reminder in output\n---\n%s", out)
+	}
+	if strings.Contains(out, "SUMMARY:One Off\r\nDTSTART;VALUE=DATE:20250315\r\nRRULE") {
+		t.Errorf("expected one_time reminder to carry no RRULE\n---\n%s", out)
+	}
+}
+
+func TestExportVaultICSLunarMonthDayProjection(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	cfg := testutil.TestJWTConfig()
+	authSvc := NewAuthService(db, cfg)
+	vaultSvc := NewVaultService(db)
+
+	resp, err := authSvc.Register(dto.RegisterRequest{
+		FirstName: "Ical",
+		LastName:  "Lunar",
+		Email:     "ical-lunar@example.com",
+		Password:  "password123",
+	}, "en")
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	vault, err := vaultSvc.CreateVault(resp.User.AccountID, resp.User.ID, dto.CreateVaultRequest{Name: "Lunar Vault"}, "en")
+	if err != nil {
+		t.Fatalf("CreateVault failed: %v", err)
+	}
+	contactSvc := NewContactService(db)
+	contact, err := contactSvc.CreateContact(vault.ID, resp.User.ID, dto.CreateContactRequest{FirstName: "Jane"})
+	if err != nil {
+		t.Fatalf("CreateContact failed: %v", err)
+	}
+
+	// Lunar month+day only: stored Year is nil, so DTSTART must be projected
+	// onto the current year and coincide with the first RDATE instead of
+	// degrading to a phantom Jan 1.
+	origDay, origMonth := 5, 8
+	if err := db.Create(&models.ContactImportantDate{
+		ContactID:      contact.ID,
+		Label:          "Lunar Fest",
+		CalendarType:   "lunar",
+		OriginalDay:    &origDay,
+		OriginalMonth:  &origMonth,
+		IsYearUnknown:  true,
+		DatePrecision:  "full",
+	}).Error; err != nil {
+		t.Fatalf("create lunar important date failed: %v", err)
+	}
+
+	svc := NewCalendarICSService(db)
+	data, err := svc.ExportVault(vault.ID, resp.User.ID)
+	if err != nil {
+		t.Fatalf("ExportVault failed: %v", err)
+	}
+	out := string(data)
+
+	if !strings.Contains(out, "DTSTART;VALUE=DATE:") {
+		t.Fatalf("expected a projected DTSTART\n---\n%s", out)
+	}
+	if !strings.Contains(out, "RDATE;VALUE=DATE:") {
+		t.Fatalf("expected RDATE projections for lunar recurrence\n---\n%s", out)
+	}
+	// The DTSTART must be the first RDATE entry, never a Jan 1 phantom.
+	if strings.Contains(out, "DTSTART;VALUE=DATE:"+time.Now().Format("2006")+"0101") {
+		t.Errorf("expected DTSTART to be a projected lunar date, not Jan 1 of the current year\n---\n%s", out)
+	}
+}

--- a/server/internal/services/calendar_ics_test.go
+++ b/server/internal/services/calendar_ics_test.go
@@ -1,10 +1,12 @@
 package services
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	calendarPkg "github.com/naiba/bonds/internal/calendar"
 	"github.com/naiba/bonds/internal/dto"
 	"github.com/naiba/bonds/internal/models"
 	"github.com/naiba/bonds/internal/testutil"
@@ -386,13 +388,13 @@ func TestExportVaultICSLunarMonthDayProjection(t *testing.T) {
 	// degrading to a phantom Jan 1.
 	origDay, origMonth := 5, 8
 	if err := db.Create(&models.ContactImportantDate{
-		ContactID:      contact.ID,
-		Label:          "Lunar Fest",
-		CalendarType:   "lunar",
-		OriginalDay:    &origDay,
-		OriginalMonth:  &origMonth,
-		IsYearUnknown:  true,
-		DatePrecision:  "full",
+		ContactID:     contact.ID,
+		Label:         "Lunar Fest",
+		CalendarType:  "lunar",
+		OriginalDay:   &origDay,
+		OriginalMonth: &origMonth,
+		IsYearUnknown: true,
+		DatePrecision: "full",
 	}).Error; err != nil {
 		t.Fatalf("create lunar important date failed: %v", err)
 	}
@@ -414,4 +416,95 @@ func TestExportVaultICSLunarMonthDayProjection(t *testing.T) {
 	if strings.Contains(out, "DTSTART;VALUE=DATE:"+time.Now().Format("2006")+"0101") {
 		t.Errorf("expected DTSTART to be a projected lunar date, not Jan 1 of the current year\n---\n%s", out)
 	}
+}
+
+func TestExportVaultICSLunarReminderIgnoresStored2000Projection(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	authSvc := NewAuthService(db, testutil.TestJWTConfig())
+	vaultSvc := NewVaultService(db)
+	resp, err := authSvc.Register(dto.RegisterRequest{
+		FirstName: "Ical",
+		LastName:  "Reminder",
+		Email:     "ical-lunar-reminder@example.com",
+		Password:  "password123",
+	}, "en")
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	vault, err := vaultSvc.CreateVault(resp.User.AccountID, resp.User.ID, dto.CreateVaultRequest{Name: "Lunar Reminder Vault"}, "en")
+	if err != nil {
+		t.Fatalf("CreateVault failed: %v", err)
+	}
+	contact, err := NewContactService(db).CreateContact(vault.ID, resp.User.ID, dto.CreateContactRequest{FirstName: "Jane"})
+	if err != nil {
+		t.Fatalf("CreateContact failed: %v", err)
+	}
+
+	converter, ok := calendarPkg.Get(calendarPkg.Lunar)
+	if !ok {
+		t.Fatal("expected lunar converter")
+	}
+	origDay, origMonth := 1, 1
+	stored, err := calendarOccurrenceInYear(converter, calendarPkg.DateInfo{Day: origDay, Month: origMonth}, calendarProjectionReferenceYear)
+	if err != nil {
+		t.Fatalf("project storage reference date: %v", err)
+	}
+	storedDay, storedMonth, storedYear := stored.Day, stored.Month, stored.Year
+	reminder := models.ContactReminder{
+		ContactID:     contact.ID,
+		Label:         "Lunar Reminder",
+		Day:           &storedDay,
+		Month:         &storedMonth,
+		Year:          &storedYear,
+		CalendarType:  "lunar",
+		OriginalDay:   &origDay,
+		OriginalMonth: &origMonth,
+		Type:          "recurring_year",
+	}
+	if err := db.Create(&reminder).Error; err != nil {
+		t.Fatalf("create lunar reminder failed: %v", err)
+	}
+
+	data, err := NewCalendarICSService(db).ExportVault(vault.ID, resp.User.ID)
+	if err != nil {
+		t.Fatalf("ExportVault failed: %v", err)
+	}
+	block := icsEventBlockForSummary(t, string(data), "Lunar Reminder")
+	currentYear := time.Now().UTC().Year()
+	expectedStart, err := calendarOccurrenceInYear(converter, calendarPkg.DateInfo{Day: origDay, Month: origMonth}, currentYear)
+	if err != nil {
+		t.Fatalf("project current occurrence: %v", err)
+	}
+	expectedStartValue := fmt.Sprintf("%04d%02d%02d", expectedStart.Year, expectedStart.Month, expectedStart.Day)
+	if !strings.Contains(block, "DTSTART;VALUE=DATE:"+expectedStartValue) {
+		t.Fatalf("expected current-year DTSTART %s, got\n---\n%s", expectedStartValue, block)
+	}
+	if strings.Contains(block, "DTSTART;VALUE=DATE:2000") {
+		t.Fatalf("expected DTSTART to ignore fixed 2000 storage projection\n---\n%s", block)
+	}
+
+	startCalendarYear := calendarYearForGregorianDate(converter, time.Date(expectedStart.Year, time.Month(expectedStart.Month), expectedStart.Day, 0, 0, 0, 0, time.UTC))
+	beyondOldHorizon, err := converter.ToGregorian(calendarPkg.DateInfo{Day: origDay, Month: origMonth, Year: startCalendarYear + 20})
+	if err != nil {
+		t.Fatalf("project occurrence beyond old horizon: %v", err)
+	}
+	beyondOldHorizonValue := fmt.Sprintf("%04d%02d%02d", beyondOldHorizon.Year, beyondOldHorizon.Month, beyondOldHorizon.Day)
+	if !strings.Contains(block, beyondOldHorizonValue) {
+		t.Fatalf("expected rolling recurrence to include %s beyond the old 10-year horizon\n---\n%s", beyondOldHorizonValue, block)
+	}
+}
+
+func icsEventBlockForSummary(t *testing.T, output, summary string) string {
+	t.Helper()
+	marker := "SUMMARY:" + summary + "\r\n"
+	markerIndex := strings.Index(output, marker)
+	if markerIndex < 0 {
+		t.Fatalf("missing event summary %q\n---\n%s", summary, output)
+	}
+	start := strings.LastIndex(output[:markerIndex], "BEGIN:VEVENT")
+	endOffset := strings.Index(output[markerIndex:], "END:VEVENT")
+	if start < 0 || endOffset < 0 {
+		t.Fatalf("invalid event block for summary %q\n---\n%s", summary, output)
+	}
+	return output[start : markerIndex+endOffset+len("END:VEVENT")]
 }

--- a/web/src/pages/contact/modules/ActivitiesModule.tsx
+++ b/web/src/pages/contact/modules/ActivitiesModule.tsx
@@ -31,6 +31,7 @@ import type {
 import ContactMentionEditor from "@/components/journal/ContactMentionEditor";
 import ContactMentionText from "@/components/journal/ContactMentionText";
 import CalendarDatePicker from "@/components/CalendarDatePicker";
+import { dateInputToTimestamp } from "@/utils/dateOnlyInput";
 import type { CalendarDatePickerValue } from "@/components/CalendarDatePicker";
 import { getCalendarSystem } from "@/utils/calendar";
 import { formatDate, formatMonthYear, useDateFormat } from "@/utils/dateFormat";
@@ -179,9 +180,9 @@ export default function ActivitiesModule({
         title: values.title,
         description,
         start_date: gregorianStart
-          ? dayjs(
+          ? dateInputToTimestamp(
               `${gregorianStart.year}-${String(gregorianStart.month).padStart(2, "0")}-${String(gregorianStart.day).padStart(2, "0")}`,
-            ).toISOString()
+            )
           : undefined,
         start_precision: startPrecision as Precision,
         calendar_type: start.calendarType,
@@ -199,8 +200,8 @@ export default function ActivitiesModule({
             : (start.year ?? undefined),
         end_status: values.end_status,
         end_date:
-          values.end_status === "known"
-            ? values.end_date?.toISOString()
+          values.end_status === "known" && values.end_date
+            ? dateInputToTimestamp(values.end_date.format("YYYY-MM-DD"))
             : undefined,
         end_precision:
           values.end_status === "known" ? values.end_precision : undefined,

--- a/web/src/pages/vault/VaultReminders.tsx
+++ b/web/src/pages/vault/VaultReminders.tsx
@@ -1,4 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
+import dayjs from "dayjs";
 import { formatContactName, useNameOrder } from "@/utils/nameFormat";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
@@ -6,7 +7,7 @@ import { Typography, Button, Table, theme, Tag } from "antd";
 import { BellOutlined, ArrowLeftOutlined } from "@ant-design/icons";
 import { api } from "@/api";
 import type { Reminder } from "@/api";
-import { useDateFormat, formatDate, formatShortDate } from "@/utils/dateFormat";
+import { useDateFormat } from "@/utils/dateFormat";
 import { queryKeyPrefixes } from "@/utils/queryInvalidation";
 
 const { Title, Text } = Typography;
@@ -140,9 +141,12 @@ export default function VaultReminders() {
               const mm = String(record.month).padStart(2, "0");
               const dd = String(record.day).padStart(2, "0");
               const probe = `${record.year ?? 2000}-${mm}-${dd}`;
+              // Format the date components directly: year/month/day are
+              // timezone-free, so applyTz (user timezone preference) would
+              // shift them by a day on either side of UTC.
               return record.year != null
-                ? formatDate(probe, dateFormats)
-                : formatShortDate(probe, dateFormats);
+                ? dayjs(probe).format(dateFormats.full)
+                : dayjs(probe).format(dateFormats.short);
             },
             sorter: (a, b) => {
               if (!a.year) return -1;

--- a/web/src/pages/vault/VaultReports.tsx
+++ b/web/src/pages/vault/VaultReports.tsx
@@ -287,11 +287,18 @@ export default function VaultReports() {
                   {
                     title: t("vault.reports.col_date"),
                     key: "date",
-                    render: (_, r) => (
-                      <span>
-                        {r.year ? r.year + "-" : ""}{String(r.month).padStart(2, '0')}-{String(r.day).padStart(2, '0')}
-                      </span>
-                    ),
+                    render: (_, r) => {
+                      const date = [
+                        r.year != null ? String(r.year) : null,
+                        r.month != null
+                          ? String(r.month).padStart(2, "0")
+                          : null,
+                        r.day != null ? String(r.day).padStart(2, "0") : null,
+                      ]
+                        .filter((part): part is string => part != null)
+                        .join("-");
+                      return <span>{date || "—"}</span>;
+                    },
                   },
                   {
                     title: t("vault.reports.col_calendar"),


### PR DESCRIPTION
Closes #241

## Summary / 概述

ICS export and date-rendering defects in the calendar subscription, reports and reminders views.

日历订阅 ICS 导出与报告/提醒视图的日期缺陷。

## Changes / 变更

- **D1 — Every gregorian reminder exported as yearly**: `icsReminderEvent` now maps `Type` → RRULE (`one_time` none, `recurring_week`/`recurring_month`/`recurring_year` → `FREQ=WEEKLY/MONTHLY/YEARLY` with `INTERVAL=n` from `FrequencyNumber`), so the subscription agrees with the scheduler. Important dates keep `RRULE:FREQ=YEARLY` unconditionally — the year is display-only in this app (修复前所有提醒一律每年重复且忽略间隔).
- **D2 — No-year lunar dates export a ghost duplicate**: `DTSTART` for year-less lunar dates is projected from the current year's occurrence (aligned with the first `RDATE`) instead of the 2000 projection reference (修复前订阅中同一天出现两个事件，一个错误).
- **D4 — Date-only activities shift one day for UTC+ users**: `ActivitiesModule` serializes date-only activity start/end as `T00:00:00Z` via the existing `dateInputToTimestamp` convention (修复前 UTC+8 用户的活动在订阅里提前一天).
- **D5 — Reports table renders literal "null"**: month/year-precision important dates render as `2026-03` / `2026` (or `—` when empty) instead of `2026-03-null` (修复前报告表格显示 2026-03-null).
- **D6 — Vault reminders shift one day with a non-browser preferred timezone**: date-only reminder rows are formatted directly without `applyTz` conversion; only real timestamps go through timezone conversion (修复前偏好时区与浏览器不一致时提醒日期偏移一天).

## Verification / 验证

- Go: `go build ./...` + `go vet ./...` clean; full service + handler suites pass on Linux (cgo/SQLite), including the new `TestExportVaultICSRecurrenceRules` and `TestExportVaultICSLunarMonthDayProjection` tests.
- Web: `bun run build` + `bun run lint` clean; focused unit suites pass.