### PR TITLE
feat(relationships): draw the relationship graph of a whole vault

### DIFF
--- a/server/internal/dto/relationship.go
+++ b/server/internal/dto/relationship.go
@@ -57,6 +57,25 @@ type ContactGraphResponse struct {
 	Edges []GraphEdge `json:"edges"`
 }
 
+// VaultGraphResponse is the whole-vault graph. The counts alongside the graph
+// describe what was left out of it, so the page can account for the difference
+// between the vault and the drawing.
+type VaultGraphResponse struct {
+	Nodes []GraphNode `json:"nodes"`
+	Edges []GraphEdge `json:"edges"`
+	// Components is the number of separate clusters drawn.
+	Components int `json:"components" example:"3"`
+	// IsolatedContacts counts contacts in the vault with no relationship to
+	// another contact in the same vault; they are not drawn.
+	IsolatedContacts int `json:"isolated_contacts" example:"12"`
+	// ExternalRelationships counts relationships from a contact in this vault
+	// to a readable contact outside it; they are not drawn.
+	ExternalRelationships int `json:"external_relationships" example:"4"`
+	// Truncated reports that whole components were dropped to stay within the
+	// node limit.
+	Truncated bool `json:"truncated" example:"false"`
+}
+
 type KinshipResponse struct {
 	Degree *int     `json:"degree" example:"2"`
 	Path   []string `json:"path" example:"id1,id2,id3"`

--- a/server/internal/dto/relationship.go
+++ b/server/internal/dto/relationship.go
@@ -57,6 +57,24 @@ type ContactGraphResponse struct {
 	Edges []GraphEdge `json:"edges"`
 }
 
+// GraphFacetValue is one selectable value of a facet, with how many of the
+// vault's drawable contacts carry it. Values are identified by their row id
+// rather than their name, so renaming one does not change what a saved filter
+// means.
+type GraphFacetValue struct {
+	Value string `json:"value" example:"12"`
+	Label string `json:"label" example:"Eton College"`
+	Count int    `json:"count" example:"4581"`
+}
+
+// GraphFacet is one dimension the vault graph can be narrowed by. Facets no
+// contact in the vault carries are not returned at all, so the page never
+// renders a control that could only ever match nothing.
+type GraphFacet struct {
+	Key    string            `json:"key" example:"group"`
+	Values []GraphFacetValue `json:"values"`
+}
+
 // VaultGraphResponse is the whole-vault graph. The counts alongside the graph
 // describe what was left out of it, so the page can account for the difference
 // between the vault and the drawing.
@@ -74,6 +92,14 @@ type VaultGraphResponse struct {
 	// Truncated reports that whole components were dropped to stay within the
 	// node limit.
 	Truncated bool `json:"truncated" example:"false"`
+	// Facets are the dimensions this vault can be narrowed by, with the values
+	// its drawable contacts actually carry. Always computed before the filter is
+	// applied, so a selection never narrows the list it was chosen from.
+	Facets []GraphFacet `json:"facets"`
+	// FilteredOut counts contacts that would have been drawn but for the filter:
+	// both those that failed it and those that passed but lost every partner
+	// that did not.
+	FilteredOut int `json:"filtered_out" example:"37"`
 }
 
 type KinshipResponse struct {

--- a/server/internal/handlers/relationships.go
+++ b/server/internal/handlers/relationships.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"strconv"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/naiba/bonds/internal/dto"
@@ -205,6 +206,29 @@ func (h *RelationshipHandler) GetContactGraph(c echo.Context) error {
 	return response.OK(c, graph)
 }
 
+// vaultGraphFilterFromQuery reads the facet selections off the query string.
+// Each facet may be repeated (?label=1&label=2) or comma-separated
+// (?label=1,2); both are accepted because these URLs get written by hand as
+// often as they get built.
+func vaultGraphFilterFromQuery(c echo.Context) services.VaultGraphFilter {
+	params := c.QueryParams()
+	filter := services.VaultGraphFilter{}
+	for _, key := range services.VaultGraphFacetKeys() {
+		values := make([]string, 0, len(params[key]))
+		for _, raw := range params[key] {
+			for _, value := range strings.Split(raw, ",") {
+				if trimmed := strings.TrimSpace(value); trimmed != "" {
+					values = append(values, trimmed)
+				}
+			}
+		}
+		if len(values) > 0 {
+			filter[key] = values
+		}
+	}
+	return filter
+}
+
 // GetVaultGraph godoc
 //
 //	@Summary		Get vault relationship graph
@@ -215,6 +239,12 @@ func (h *RelationshipHandler) GetContactGraph(c echo.Context) error {
 //	@Security		BearerAuth
 //	@Param			vault_id	path		string	true	"Vault ID"
 //	@Param			limit		query		integer	false	"Maximum nodes to draw (default 400)"
+//	@Param			gender		query		[]string	false	"Only draw contacts with one of these gender ids"	collectionFormat(multi)
+//	@Param			pronoun		query		[]string	false	"Only draw contacts with one of these pronoun ids"	collectionFormat(multi)
+//	@Param			religion	query		[]string	false	"Only draw contacts with one of these religion ids"	collectionFormat(multi)
+//	@Param			company		query		[]string	false	"Only draw contacts with one of these company ids"	collectionFormat(multi)
+//	@Param			label		query		[]string	false	"Only draw contacts carrying one of these label ids"	collectionFormat(multi)
+//	@Param			group		query		[]string	false	"Only draw contacts belonging to one of these group ids"	collectionFormat(multi)
 //	@Success		200			{object}	response.APIResponse{data=dto.VaultGraphResponse}
 //	@Failure		401			{object}	response.APIResponse
 //	@Failure		404			{object}	response.APIResponse
@@ -224,7 +254,7 @@ func (h *RelationshipHandler) GetVaultGraph(c echo.Context) error {
 	vaultID := c.Param("vault_id")
 	userID := middleware.GetUserID(c)
 	limit, _ := strconv.Atoi(c.QueryParam("limit"))
-	graph, err := h.relationshipService.GetVaultGraph(vaultID, userID, middleware.GetLocale(c), limit)
+	graph, err := h.relationshipService.GetVaultGraph(vaultID, userID, middleware.GetLocale(c), limit, vaultGraphFilterFromQuery(c))
 	if err != nil {
 		if errors.Is(err, services.ErrVaultNotFound) {
 			return response.NotFound(c, "err.vault_not_found")

--- a/server/internal/handlers/relationships.go
+++ b/server/internal/handlers/relationships.go
@@ -205,6 +205,35 @@ func (h *RelationshipHandler) GetContactGraph(c echo.Context) error {
 	return response.OK(c, graph)
 }
 
+// GetVaultGraph godoc
+//
+//	@Summary		Get vault relationship graph
+//	@Description	Return the relationship graph of a whole vault, with reciprocal rows collapsed and family relationships inferred. Contacts unrelated to anyone else in the vault, and relationships pointing outside it, are counted rather than drawn.
+//	@Tags			relationships
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			vault_id	path		string	true	"Vault ID"
+//	@Param			limit		query		integer	false	"Maximum nodes to draw (default 400)"
+//	@Success		200			{object}	response.APIResponse{data=dto.VaultGraphResponse}
+//	@Failure		401			{object}	response.APIResponse
+//	@Failure		404			{object}	response.APIResponse
+//	@Failure		500			{object}	response.APIResponse
+//	@Router			/vaults/{vault_id}/relationships/graph [get]
+func (h *RelationshipHandler) GetVaultGraph(c echo.Context) error {
+	vaultID := c.Param("vault_id")
+	userID := middleware.GetUserID(c)
+	limit, _ := strconv.Atoi(c.QueryParam("limit"))
+	graph, err := h.relationshipService.GetVaultGraph(vaultID, userID, middleware.GetLocale(c), limit)
+	if err != nil {
+		if errors.Is(err, services.ErrVaultNotFound) {
+			return response.NotFound(c, "err.vault_not_found")
+		}
+		return response.InternalError(c, "err.failed_to_get_graph")
+	}
+	return response.OK(c, graph)
+}
+
 // CalculateKinship godoc
 //
 //	@Summary		Calculate kinship degree between two contacts

--- a/server/internal/handlers/relationships.go
+++ b/server/internal/handlers/relationships.go
@@ -238,7 +238,7 @@ func vaultGraphFilterFromQuery(c echo.Context) services.VaultGraphFilter {
 //	@Produce		json
 //	@Security		BearerAuth
 //	@Param			vault_id	path		string	true	"Vault ID"
-//	@Param			limit		query		integer	false	"Maximum nodes to draw (default 1000)"
+//	@Param			limit		query		integer	false	"Target node budget (default 1000, maximum 5000; the largest connected component is always kept whole)"
 //	@Param			gender		query		[]string	false	"Only draw contacts with one of these gender ids"	collectionFormat(multi)
 //	@Param			pronoun		query		[]string	false	"Only draw contacts with one of these pronoun ids"	collectionFormat(multi)
 //	@Param			religion	query		[]string	false	"Only draw contacts with one of these religion ids"	collectionFormat(multi)

--- a/server/internal/handlers/relationships.go
+++ b/server/internal/handlers/relationships.go
@@ -238,7 +238,7 @@ func vaultGraphFilterFromQuery(c echo.Context) services.VaultGraphFilter {
 //	@Produce		json
 //	@Security		BearerAuth
 //	@Param			vault_id	path		string	true	"Vault ID"
-//	@Param			limit		query		integer	false	"Maximum nodes to draw (default 400)"
+//	@Param			limit		query		integer	false	"Maximum nodes to draw (default 1000)"
 //	@Param			gender		query		[]string	false	"Only draw contacts with one of these gender ids"	collectionFormat(multi)
 //	@Param			pronoun		query		[]string	false	"Only draw contacts with one of these pronoun ids"	collectionFormat(multi)
 //	@Param			religion	query		[]string	false	"Only draw contacts with one of these religion ids"	collectionFormat(multi)

--- a/server/internal/handlers/routes.go
+++ b/server/internal/handlers/routes.go
@@ -437,6 +437,9 @@ func RegisterRoutes(e *echo.Echo, db *gorm.DB, cfg *config.Config, version strin
 	vaultContactInfo := protected.Group("/vaults/:vault_id/contactInformation", VaultPermissionMiddleware(vaultService, models.PermissionViewer))
 	vaultContactInfo.GET("/by-identity", contactInformationHandler.FindByIdentity)
 
+	vaultRelationships := protected.Group("/vaults/:vault_id/relationships", VaultPermissionMiddleware(vaultService, models.PermissionViewer))
+	vaultRelationships.GET("/graph", relationshipHandler.GetVaultGraph)
+
 	contactInfo := contactSub.Group("/contactInformation")
 	contactInfo.GET("", contactInformationHandler.List)
 	contactInfo.POST("", contactInformationHandler.Create, requireEditor)

--- a/server/internal/services/relationship_graph.go
+++ b/server/internal/services/relationship_graph.go
@@ -578,7 +578,7 @@ const defaultVaultGraphNodeLimit = 400
 //     vault's business rendered on this vault's page.
 //   - Whole components past the node limit, largest first, so the cap never
 //     cuts a family in half.
-func (s *RelationshipService) GetVaultGraph(vaultID, userID, locale string, limit int) (*dto.VaultGraphResponse, error) {
+func (s *RelationshipService) GetVaultGraph(vaultID, userID, locale string, limit int, filter VaultGraphFilter) (*dto.VaultGraphResponse, error) {
 	if limit <= 0 {
 		limit = defaultVaultGraphNodeLimit
 	}
@@ -636,7 +636,20 @@ func (s *RelationshipService) GetVaultGraph(vaultID, userID, locale string, limi
 		addToContactMap(adjacency, relationship.RelatedContactID, relationship.ContactID)
 	}
 
-	components := connectedComponents(adjacency)
+	// The facet options describe the unfiltered graph, so the reader can always
+	// see the values they did not pick. The filter is applied after them.
+	facets, err := s.loadContactFacets(vaultID, locale, contacts)
+	if err != nil {
+		return nil, err
+	}
+	drawable := contactSet{}
+	for id := range adjacency {
+		drawable[id] = struct{}{}
+	}
+
+	filtered, filteredAdjacency := applyGraphFilter(adjacency, facets, filter)
+
+	components := connectedComponents(filteredAdjacency)
 	kept, keptComponents := componentsWithinLimit(components, limit)
 
 	builder := newRelationshipGraphBuilder(locale)
@@ -681,7 +694,54 @@ func (s *RelationshipService) GetVaultGraph(vaultID, userID, locale string, limi
 		IsolatedContacts:      len(contactsByID) - len(adjacency),
 		ExternalRelationships: external,
 		Truncated:             keptComponents < len(components),
+		Facets:                facets.options(drawable),
+		FilteredOut:           len(drawable) - len(filtered),
 	}, nil
+}
+
+// applyGraphFilter narrows an adjacency list to the contacts matching the
+// filter, then drops any of those left with no partner still standing.
+//
+// The second step matters: a contact who matches but whose every relation was
+// filtered away has nothing to show on a relationship graph, and drawing them
+// as a loose dot is the same noise isolated contacts were excluded to avoid.
+// Both losses are reported together, because to the reader they are one thing —
+// people the filter took off the canvas.
+func applyGraphFilter(adjacency map[string]contactSet, facets *contactFacets, filter VaultGraphFilter) (contactSet, map[string]contactSet) {
+	if len(filter) == 0 {
+		matched := contactSet{}
+		for id := range adjacency {
+			matched[id] = struct{}{}
+		}
+		return matched, adjacency
+	}
+
+	matched := contactSet{}
+	for id := range adjacency {
+		if facets.matches(id, filter) {
+			matched[id] = struct{}{}
+		}
+	}
+
+	filteredAdjacency := make(map[string]contactSet, len(matched))
+	for id := range matched {
+		neighbours := contactSet{}
+		for neighbour := range adjacency[id] {
+			if _, ok := matched[neighbour]; ok {
+				neighbours[neighbour] = struct{}{}
+			}
+		}
+		if len(neighbours) == 0 {
+			continue
+		}
+		filteredAdjacency[id] = neighbours
+	}
+
+	drawn := contactSet{}
+	for id := range filteredAdjacency {
+		drawn[id] = struct{}{}
+	}
+	return drawn, filteredAdjacency
 }
 
 // connectedComponents groups an undirected adjacency list into its connected

--- a/server/internal/services/relationship_graph.go
+++ b/server/internal/services/relationship_graph.go
@@ -557,11 +557,15 @@ func graphRelationKey(relation dto.GraphRelation) string {
 	}, "\x00")
 }
 
-// defaultVaultGraphNodeLimit bounds how much of a vault a single graph
-// response will draw. A force-directed layout stops being readable long before
-// it stops being renderable, so the cap is a legibility limit rather than a
-// performance one.
-const defaultVaultGraphNodeLimit = 1000
+// The node limit is a target budget rather than a hard cap: the largest
+// connected component is kept whole even when it exceeds the requested value.
+// Clamp user input to the largest supported UI option so a hand-written URL
+// cannot request an arbitrarily large collection of otherwise-droppable
+// components.
+const (
+	defaultVaultGraphNodeLimit = 1000
+	maxVaultGraphNodeLimit     = 5000
+)
 
 // GetVaultGraph returns the relationship graph of one vault: every contact in
 // it that is related to another contact in it, and the relationships between
@@ -579,9 +583,7 @@ const defaultVaultGraphNodeLimit = 1000
 //   - Whole components past the node limit, largest first, so the cap never
 //     cuts a family in half.
 func (s *RelationshipService) GetVaultGraph(vaultID, userID, locale string, limit int, filter VaultGraphFilter) (*dto.VaultGraphResponse, error) {
-	if limit <= 0 {
-		limit = defaultVaultGraphNodeLimit
-	}
+	limit = normalizeVaultGraphNodeLimit(limit)
 
 	accessibleVaults, err := accessibleVaultIDSet(s.db, userID)
 	if err != nil {
@@ -697,6 +699,16 @@ func (s *RelationshipService) GetVaultGraph(vaultID, userID, locale string, limi
 		Facets:                facets.options(drawable),
 		FilteredOut:           len(drawable) - len(filtered),
 	}, nil
+}
+
+func normalizeVaultGraphNodeLimit(limit int) int {
+	if limit <= 0 {
+		return defaultVaultGraphNodeLimit
+	}
+	if limit > maxVaultGraphNodeLimit {
+		return maxVaultGraphNodeLimit
+	}
+	return limit
 }
 
 // applyGraphFilter narrows an adjacency list to the contacts matching the

--- a/server/internal/services/relationship_graph.go
+++ b/server/internal/services/relationship_graph.go
@@ -561,7 +561,7 @@ func graphRelationKey(relation dto.GraphRelation) string {
 // response will draw. A force-directed layout stops being readable long before
 // it stops being renderable, so the cap is a legibility limit rather than a
 // performance one.
-const defaultVaultGraphNodeLimit = 400
+const defaultVaultGraphNodeLimit = 1000
 
 // GetVaultGraph returns the relationship graph of one vault: every contact in
 // it that is related to another contact in it, and the relationships between

--- a/server/internal/services/relationship_graph.go
+++ b/server/internal/services/relationship_graph.go
@@ -556,3 +556,195 @@ func graphRelationKey(relation dto.GraphRelation) string {
 		strconv.Itoa(relation.Generations),
 	}, "\x00")
 }
+
+// defaultVaultGraphNodeLimit bounds how much of a vault a single graph
+// response will draw. A force-directed layout stops being readable long before
+// it stops being renderable, so the cap is a legibility limit rather than a
+// performance one.
+const defaultVaultGraphNodeLimit = 400
+
+// GetVaultGraph returns the relationship graph of one vault: every contact in
+// it that is related to another contact in it, and the relationships between
+// them, with the same inference the single-contact graph applies.
+//
+// Three deliberate exclusions, each reported back so the page can say what is
+// missing rather than quietly showing less than the whole truth:
+//
+//   - Contacts with no in-vault relationship. A vault is mostly people who are
+//     in it for their own sake, and drawing them as unconnected dots buries the
+//     structure the page exists to show.
+//   - Relationships that leave the vault. bonds allows them, but a vault-scoped
+//     view that silently pulled in contacts from elsewhere would be a different
+//     vault's business rendered on this vault's page.
+//   - Whole components past the node limit, largest first, so the cap never
+//     cuts a family in half.
+func (s *RelationshipService) GetVaultGraph(vaultID, userID, locale string, limit int) (*dto.VaultGraphResponse, error) {
+	if limit <= 0 {
+		limit = defaultVaultGraphNodeLimit
+	}
+
+	accessibleVaults, err := accessibleVaultIDSet(s.db, userID)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := accessibleVaults[vaultID]; !ok {
+		return nil, ErrVaultNotFound
+	}
+
+	var contacts []models.Contact
+	if err := s.db.Where("vault_id = ?", vaultID).Find(&contacts).Error; err != nil {
+		return nil, err
+	}
+	contactsByID := make(map[string]models.Contact, len(contacts))
+	for _, contact := range contacts {
+		contactsByID[contact.ID] = contact
+	}
+
+	var relationships []models.Relationship
+	if err := s.db.
+		Preload("RelationshipType").
+		Preload("Contact").
+		Preload("RelatedContact").
+		Where("contact_id IN (SELECT id FROM contacts WHERE vault_id = ?)", vaultID).
+		Order("id ASC").
+		Find(&relationships).Error; err != nil {
+		return nil, err
+	}
+
+	// Split the relationships into the ones that stay inside the vault and the
+	// ones that leave it. The second group is counted, not drawn.
+	adjacency := make(map[string]contactSet)
+	internal := make([]models.Relationship, 0, len(relationships))
+	external := 0
+	for _, relationship := range relationships {
+		if relationship.ContactID == relationship.RelatedContactID {
+			continue
+		}
+		_, sourceInVault := contactsByID[relationship.ContactID]
+		_, targetInVault := contactsByID[relationship.RelatedContactID]
+		if !sourceInVault || !targetInVault {
+			// Only count it if the far end is one this user could otherwise see;
+			// a relationship into a vault they have no access to is not
+			// something to advertise the existence of.
+			if canReadContactInVault(accessibleVaults, relationship.RelatedContact) {
+				external++
+			}
+			continue
+		}
+		internal = append(internal, relationship)
+		addToContactMap(adjacency, relationship.ContactID, relationship.RelatedContactID)
+		addToContactMap(adjacency, relationship.RelatedContactID, relationship.ContactID)
+	}
+
+	components := connectedComponents(adjacency)
+	kept, keptComponents := componentsWithinLimit(components, limit)
+
+	builder := newRelationshipGraphBuilder(locale)
+	for _, relationship := range internal {
+		if !containsContact(kept, relationship.ContactID) {
+			continue
+		}
+		if !containsContact(kept, relationship.RelatedContactID) {
+			continue
+		}
+		builder.addExplicitRelationship(relationship)
+	}
+	builder.inferFamilyRelationships(kept)
+
+	formatter, err := newContactNameFormatter(s.db, userID)
+	if err != nil {
+		return nil, err
+	}
+	nodes := make([]dto.GraphNode, 0, len(kept))
+	for id := range kept {
+		contact, ok := contactsByID[id]
+		if !ok {
+			continue
+		}
+		label, err := formatter.format(&contact, "")
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, dto.GraphNode{ID: id, Label: label})
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].Label != nodes[j].Label {
+			return nodes[i].Label < nodes[j].Label
+		}
+		return nodes[i].ID < nodes[j].ID
+	})
+
+	return &dto.VaultGraphResponse{
+		Nodes:                 nodes,
+		Edges:                 builder.buildEdges(),
+		Components:            keptComponents,
+		IsolatedContacts:      len(contactsByID) - len(adjacency),
+		ExternalRelationships: external,
+		Truncated:             keptComponents < len(components),
+	}, nil
+}
+
+// connectedComponents groups an undirected adjacency list into its connected
+// components, largest first.
+func connectedComponents(adjacency map[string]contactSet) []contactSet {
+	seen := contactSet{}
+	components := make([]contactSet, 0)
+	for _, start := range sortedAdjacencyKeys(adjacency) {
+		if _, done := seen[start]; done {
+			continue
+		}
+		component := contactSet{start: {}}
+		seen[start] = struct{}{}
+		queue := []string{start}
+		for len(queue) > 0 {
+			current := queue[0]
+			queue = queue[1:]
+			for _, neighbor := range sortedContactIDs(adjacency[current]) {
+				if _, done := seen[neighbor]; done {
+					continue
+				}
+				seen[neighbor] = struct{}{}
+				component[neighbor] = struct{}{}
+				queue = append(queue, neighbor)
+			}
+		}
+		components = append(components, component)
+	}
+	sort.SliceStable(components, func(i, j int) bool {
+		if len(components[i]) != len(components[j]) {
+			return len(components[i]) > len(components[j])
+		}
+		return sortedContactIDs(components[i])[0] < sortedContactIDs(components[j])[0]
+	})
+	return components
+}
+
+// componentsWithinLimit takes whole components, largest first, and stops at the
+// first one that would not fit. It returns the union of what it took and how
+// many components that was. The largest component is always taken even when it
+// exceeds the limit on its own, because returning an empty graph is a worse
+// answer than returning one oversized cluster the caller can be told about.
+func componentsWithinLimit(components []contactSet, limit int) (contactSet, int) {
+	kept := contactSet{}
+	for index, component := range components {
+		if index > 0 && len(kept)+len(component) > limit {
+			// Stop rather than skip: components arrive largest first, so a
+			// later smaller one squeezing in would drop a bigger cluster in
+			// favour of a lesser one.
+			return kept, index
+		}
+		for id := range component {
+			kept[id] = struct{}{}
+		}
+	}
+	return kept, len(components)
+}
+
+func sortedAdjacencyKeys(adjacency map[string]contactSet) []string {
+	keys := make([]string, 0, len(adjacency))
+	for key := range adjacency {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/server/internal/services/relationship_graph_facets.go
+++ b/server/internal/services/relationship_graph_facets.go
@@ -1,0 +1,318 @@
+package services
+
+import (
+	"sort"
+	"strconv"
+
+	"github.com/naiba/bonds/internal/dto"
+	"github.com/naiba/bonds/internal/i18n"
+	"github.com/naiba/bonds/internal/models"
+)
+
+// The dimensions the vault graph can be narrowed by. These are the attributes
+// a contact carries directly or through a pivot; anything requiring a join
+// through another contact is deliberately not a facet, because narrowing a
+// relationship graph by a relationship is what the graph itself is for.
+const (
+	facetGender   = "gender"
+	facetPronoun  = "pronoun"
+	facetReligion = "religion"
+	facetCompany  = "company"
+	facetLabel    = "label"
+	facetGroup    = "group"
+)
+
+// facetOrder fixes the order facets are returned in, so the filter bar does not
+// reshuffle itself between requests.
+var facetOrder = []string{facetGender, facetPronoun, facetReligion, facetCompany, facetLabel, facetGroup}
+
+// VaultGraphFilter narrows which contacts are drawn, keyed by facet. Within one
+// facet the selected values are OR-ed (a contact tagged either "school" or
+// "family" matches both); across facets they are AND-ed (that contact must also
+// match every other facet that has a selection). Facets with no selection do
+// not constrain anything.
+type VaultGraphFilter map[string][]string
+
+// selection returns the chosen values of one facet as a set, and whether that
+// facet constrains the graph at all.
+func (f VaultGraphFilter) selection(key string) (map[string]struct{}, bool) {
+	values := f[key]
+	if len(values) == 0 {
+		return nil, false
+	}
+	selected := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value != "" {
+			selected[value] = struct{}{}
+		}
+	}
+	return selected, len(selected) > 0
+}
+
+// contactFacets holds, for one vault, which facet values each contact carries
+// and what each value is called. Values are identified by their numeric row id
+// rather than their name, so a rename does not silently change what a saved
+// filter means.
+type contactFacets struct {
+	// byContact[contactID][facetKey] is the set of value ids that contact has.
+	byContact map[string]map[string]map[string]struct{}
+	// names[facetKey][valueID] is the display label for that value.
+	names map[string]map[string]string
+}
+
+func newContactFacets() *contactFacets {
+	return &contactFacets{
+		byContact: make(map[string]map[string]map[string]struct{}),
+		names:     make(map[string]map[string]string),
+	}
+}
+
+func (c *contactFacets) add(contactID, facetKey, valueID, name string) {
+	if valueID == "" || name == "" {
+		return
+	}
+	facets, ok := c.byContact[contactID]
+	if !ok {
+		facets = make(map[string]map[string]struct{}, 2)
+		c.byContact[contactID] = facets
+	}
+	values, ok := facets[facetKey]
+	if !ok {
+		values = make(map[string]struct{}, 1)
+		facets[facetKey] = values
+	}
+	values[valueID] = struct{}{}
+
+	labels, ok := c.names[facetKey]
+	if !ok {
+		labels = make(map[string]string, 1)
+		c.names[facetKey] = labels
+	}
+	labels[valueID] = name
+}
+
+// matches reports whether a contact satisfies every facet the filter constrains.
+func (c *contactFacets) matches(contactID string, filter VaultGraphFilter) bool {
+	for _, key := range facetOrder {
+		selected, constrains := filter.selection(key)
+		if !constrains {
+			continue
+		}
+		values := c.byContact[contactID][key]
+		found := false
+		for value := range values {
+			if _, ok := selected[value]; ok {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// options lists the facet values carried by the given contacts, with counts.
+//
+// The caller passes the contacts that are drawable *before* any filter is
+// applied, on purpose: computing the options from the filtered set would make
+// every selection narrow the list it was chosen from, and a reader who picked
+// one value could never see the others to pick again.
+func (c *contactFacets) options(drawable contactSet) []dto.GraphFacet {
+	counts := make(map[string]map[string]int, len(facetOrder))
+	for contactID := range drawable {
+		for key, values := range c.byContact[contactID] {
+			perFacet, ok := counts[key]
+			if !ok {
+				perFacet = make(map[string]int)
+				counts[key] = perFacet
+			}
+			for value := range values {
+				perFacet[value]++
+			}
+		}
+	}
+
+	facets := make([]dto.GraphFacet, 0, len(facetOrder))
+	for _, key := range facetOrder {
+		perFacet := counts[key]
+		if len(perFacet) == 0 {
+			// A facet nothing in this vault carries is left out entirely rather
+			// than returned empty, so the page never renders a control that
+			// could only ever match nothing.
+			continue
+		}
+		values := make([]dto.GraphFacetValue, 0, len(perFacet))
+		for value, count := range perFacet {
+			values = append(values, dto.GraphFacetValue{
+				Value: value,
+				Label: c.names[key][value],
+				Count: count,
+			})
+		}
+		sort.Slice(values, func(i, j int) bool {
+			if values[i].Count != values[j].Count {
+				return values[i].Count > values[j].Count
+			}
+			return values[i].Label < values[j].Label
+		})
+		facets = append(facets, dto.GraphFacet{Key: key, Values: values})
+	}
+	return facets
+}
+
+// translatedName prefers the seeded translation key over the stored name, which
+// is how the rest of the codebase renders these lookup rows.
+func translatedName(locale string, name, translationKey *string) string {
+	if translationKey != nil && *translationKey != "" {
+		return i18n.T(locale, *translationKey)
+	}
+	if name != nil {
+		return *name
+	}
+	return ""
+}
+
+// loadContactFacets reads the facet values of every contact in the vault.
+//
+// The lookup tables are read by the ids the contacts actually reference rather
+// than by account, so this can never surface a value belonging to an account
+// the caller has nothing to do with.
+func (s *RelationshipService) loadContactFacets(vaultID, locale string, contacts []models.Contact) (*contactFacets, error) {
+	facets := newContactFacets()
+
+	genderIDs := make([]uint, 0)
+	pronounIDs := make([]uint, 0)
+	religionIDs := make([]uint, 0)
+	companyIDs := make([]uint, 0)
+	for _, contact := range contacts {
+		if contact.GenderID != nil {
+			genderIDs = append(genderIDs, *contact.GenderID)
+		}
+		if contact.PronounID != nil {
+			pronounIDs = append(pronounIDs, *contact.PronounID)
+		}
+		if contact.ReligionID != nil {
+			religionIDs = append(religionIDs, *contact.ReligionID)
+		}
+		if contact.CompanyID != nil {
+			companyIDs = append(companyIDs, *contact.CompanyID)
+		}
+	}
+
+	genderNames := make(map[uint]string, len(genderIDs))
+	if len(genderIDs) > 0 {
+		var rows []models.Gender
+		if err := s.db.Where("id IN ?", uniqueUints(genderIDs)).Find(&rows).Error; err != nil {
+			return nil, err
+		}
+		for _, row := range rows {
+			genderNames[row.ID] = translatedName(locale, row.Name, row.NameTranslationKey)
+		}
+	}
+
+	pronounNames := make(map[uint]string, len(pronounIDs))
+	if len(pronounIDs) > 0 {
+		var rows []models.Pronoun
+		if err := s.db.Where("id IN ?", uniqueUints(pronounIDs)).Find(&rows).Error; err != nil {
+			return nil, err
+		}
+		for _, row := range rows {
+			pronounNames[row.ID] = translatedName(locale, row.Name, row.NameTranslationKey)
+		}
+	}
+
+	religionNames := make(map[uint]string, len(religionIDs))
+	if len(religionIDs) > 0 {
+		var rows []models.Religion
+		if err := s.db.Where("id IN ?", uniqueUints(religionIDs)).Find(&rows).Error; err != nil {
+			return nil, err
+		}
+		for _, row := range rows {
+			religionNames[row.ID] = translatedName(locale, row.Name, row.TranslationKey)
+		}
+	}
+
+	companyNames := make(map[uint]string, len(companyIDs))
+	if len(companyIDs) > 0 {
+		var rows []models.Company
+		if err := s.db.Where("id IN ?", uniqueUints(companyIDs)).Find(&rows).Error; err != nil {
+			return nil, err
+		}
+		for _, row := range rows {
+			companyNames[row.ID] = row.Name
+		}
+	}
+
+	for _, contact := range contacts {
+		if contact.GenderID != nil {
+			facets.add(contact.ID, facetGender, strconv.FormatUint(uint64(*contact.GenderID), 10), genderNames[*contact.GenderID])
+		}
+		if contact.PronounID != nil {
+			facets.add(contact.ID, facetPronoun, strconv.FormatUint(uint64(*contact.PronounID), 10), pronounNames[*contact.PronounID])
+		}
+		if contact.ReligionID != nil {
+			facets.add(contact.ID, facetReligion, strconv.FormatUint(uint64(*contact.ReligionID), 10), religionNames[*contact.ReligionID])
+		}
+		if contact.CompanyID != nil {
+			facets.add(contact.ID, facetCompany, strconv.FormatUint(uint64(*contact.CompanyID), 10), companyNames[*contact.CompanyID])
+		}
+	}
+
+	// Labels and groups are pivots, so they are read with a subquery on the
+	// vault rather than by passing every contact id as a bind variable.
+	type pivotRow struct {
+		ContactID string
+		ValueID   uint
+		Name      string
+	}
+
+	var labelRows []pivotRow
+	if err := s.db.Table("contact_label").
+		Select("contact_label.contact_id AS contact_id, labels.id AS value_id, labels.name AS name").
+		Joins("JOIN labels ON labels.id = contact_label.label_id").
+		Where("contact_label.contact_id IN (SELECT id FROM contacts WHERE vault_id = ?)", vaultID).
+		Scan(&labelRows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range labelRows {
+		facets.add(row.ContactID, facetLabel, strconv.FormatUint(uint64(row.ValueID), 10), row.Name)
+	}
+
+	var groupRows []pivotRow
+	if err := s.db.Table("contact_group").
+		Select("contact_group.contact_id AS contact_id, groups.id AS value_id, groups.name AS name").
+		Joins("JOIN groups ON groups.id = contact_group.group_id").
+		Where("contact_group.contact_id IN (SELECT id FROM contacts WHERE vault_id = ?)", vaultID).
+		Scan(&groupRows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range groupRows {
+		facets.add(row.ContactID, facetGroup, strconv.FormatUint(uint64(row.ValueID), 10), row.Name)
+	}
+
+	return facets, nil
+}
+
+func uniqueUints(values []uint) []uint {
+	seen := make(map[uint]struct{}, len(values))
+	unique := make([]uint, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
+}
+
+// VaultGraphFacetKeys lists the facet keys the vault graph accepts, in the
+// order they are returned. Exported so the transport layer reads the same set
+// the service filters on rather than keeping its own copy in step by hand.
+func VaultGraphFacetKeys() []string {
+	keys := make([]string, len(facetOrder))
+	copy(keys, facetOrder)
+	return keys
+}

--- a/server/internal/services/relationship_graph_facets.go
+++ b/server/internal/services/relationship_graph_facets.go
@@ -181,6 +181,11 @@ func translatedName(locale string, name, translationKey *string) string {
 // the caller has nothing to do with.
 func (s *RelationshipService) loadContactFacets(vaultID, locale string, contacts []models.Contact) (*contactFacets, error) {
 	facets := newContactFacets()
+	type pivotRow struct {
+		ContactID string
+		ValueID   uint
+		Name      string
+	}
 
 	genderIDs := make([]uint, 0)
 	pronounIDs := make([]uint, 0)
@@ -199,6 +204,21 @@ func (s *RelationshipService) loadContactFacets(vaultID, locale string, contacts
 		if contact.CompanyID != nil {
 			companyIDs = append(companyIDs, *contact.CompanyID)
 		}
+	}
+
+	// Employment is stored in contact_companies by the current jobs API. Keep
+	// reading Contact.CompanyID above for legacy rows, but build the facet from
+	// the union so newly-created and multiple employments are represented.
+	var companyRows []pivotRow
+	if err := s.db.Table("contact_companies").
+		Select("contact_companies.contact_id AS contact_id, companies.id AS value_id, companies.name AS name").
+		Joins("JOIN companies ON companies.id = contact_companies.company_id").
+		Where("contact_companies.contact_id IN (SELECT id FROM contacts WHERE vault_id = ?)", vaultID).
+		Scan(&companyRows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range companyRows {
+		companyIDs = append(companyIDs, row.ValueID)
 	}
 
 	genderNames := make(map[uint]string, len(genderIDs))
@@ -259,15 +279,12 @@ func (s *RelationshipService) loadContactFacets(vaultID, locale string, contacts
 			facets.add(contact.ID, facetCompany, strconv.FormatUint(uint64(*contact.CompanyID), 10), companyNames[*contact.CompanyID])
 		}
 	}
+	for _, row := range companyRows {
+		facets.add(row.ContactID, facetCompany, strconv.FormatUint(uint64(row.ValueID), 10), row.Name)
+	}
 
 	// Labels and groups are pivots, so they are read with a subquery on the
 	// vault rather than by passing every contact id as a bind variable.
-	type pivotRow struct {
-		ContactID string
-		ValueID   uint
-		Name      string
-	}
-
 	var labelRows []pivotRow
 	if err := s.db.Table("contact_label").
 		Select("contact_label.contact_id AS contact_id, labels.id AS value_id, labels.name AS name").

--- a/server/internal/services/relationship_vault_graph_facet_test.go
+++ b/server/internal/services/relationship_vault_graph_facet_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/naiba/bonds/internal/dto"
 	"github.com/naiba/bonds/internal/models"
 )
 
@@ -286,6 +287,54 @@ func TestVaultGraphFiltersByGenderLikeAnyOtherFacet(t *testing.T) {
 	}
 	if !genderFacet {
 		t.Error("gender facet missing even though contacts carry one")
+	}
+}
+
+func TestVaultGraphCompanyFacetUsesCurrentContactJobs(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+
+	company := models.Company{VaultID: ctx.vaultID, Name: "Acme"}
+	if err := ctx.db.Create(&company).Error; err != nil {
+		t.Fatalf("create company: %v", err)
+	}
+	jobService := NewContactJobService(ctx.db)
+	for _, contactID := range []string{ctx.contactID, ctx.relatedContactID} {
+		if _, err := jobService.Create(contactID, ctx.vaultID, dto.CreateContactJobRequest{
+			CompanyID: company.ID,
+		}); err != nil {
+			t.Fatalf("create current contact job for %s: %v", contactID, err)
+		}
+	}
+
+	companyID := uintToString(company.ID)
+	unfiltered, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0, nil)
+	if err != nil {
+		t.Fatalf("GetVaultGraph: %v", err)
+	}
+	var found bool
+	for _, facet := range unfiltered.Facets {
+		if facet.Key != facetCompany {
+			continue
+		}
+		for _, value := range facet.Values {
+			if value.Value == companyID && value.Label == company.Name && value.Count == 2 {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("company from contact_companies was not offered as a facet")
+	}
+
+	filtered, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0,
+		VaultGraphFilter{facetCompany: {companyID}})
+	if err != nil {
+		t.Fatalf("GetVaultGraph filtered by current contact job: %v", err)
+	}
+	if len(filtered.Nodes) != 2 || filtered.FilteredOut != 0 {
+		t.Fatalf("company filter should draw both current employees: nodes=%d filtered_out=%d", len(filtered.Nodes), filtered.FilteredOut)
 	}
 }
 

--- a/server/internal/services/relationship_vault_graph_facet_test.go
+++ b/server/internal/services/relationship_vault_graph_facet_test.go
@@ -1,0 +1,314 @@
+package services
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/naiba/bonds/internal/models"
+)
+
+func labelContact(t *testing.T, ctx relationshipTestCtx, name string, contactIDs ...string) string {
+	t.Helper()
+	label := models.Label{VaultID: ctx.vaultID, Name: name, Slug: name}
+	if err := ctx.db.Create(&label).Error; err != nil {
+		t.Fatalf("create label %q: %v", name, err)
+	}
+	for _, contactID := range contactIDs {
+		if err := ctx.db.Create(&models.ContactLabel{LabelID: label.ID, ContactID: contactID}).Error; err != nil {
+			t.Fatalf("attach label %q to %s: %v", name, contactID, err)
+		}
+	}
+	return uintToString(label.ID)
+}
+
+func groupContact(t *testing.T, ctx relationshipTestCtx, name string, contactIDs ...string) string {
+	t.Helper()
+	group := models.Group{VaultID: ctx.vaultID, Name: name}
+	if err := ctx.db.Create(&group).Error; err != nil {
+		t.Fatalf("create group %q: %v", name, err)
+	}
+	for _, contactID := range contactIDs {
+		if err := ctx.db.Create(&models.ContactGroup{GroupID: group.ID, ContactID: contactID}).Error; err != nil {
+			t.Fatalf("attach group %q to %s: %v", name, contactID, err)
+		}
+	}
+	return uintToString(group.ID)
+}
+
+func genderContact(t *testing.T, ctx relationshipTestCtx, name string, contactIDs ...string) string {
+	t.Helper()
+	gender := models.Gender{AccountID: ctx.accountID, Name: &name}
+	if err := ctx.db.Create(&gender).Error; err != nil {
+		t.Fatalf("create gender %q: %v", name, err)
+	}
+	for _, contactID := range contactIDs {
+		if err := ctx.db.Model(&models.Contact{}).Where("id = ?", contactID).
+			Update("gender_id", gender.ID).Error; err != nil {
+			t.Fatalf("set gender %q on %s: %v", name, contactID, err)
+		}
+	}
+	return uintToString(gender.ID)
+}
+
+func uintToString(value uint) string {
+	return strconv.FormatUint(uint64(value), 10)
+}
+
+func nodeIDs(t *testing.T, ids []string) map[string]struct{} {
+	t.Helper()
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set
+}
+
+// A facet nobody carries is not a filter anyone can use, so it is left out
+// rather than rendered as an empty control.
+func TestVaultGraphFacetsListOnlyWhatTheVaultCarries(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+	schoolID := labelContact(t, ctx, "school", ctx.contactID, ctx.relatedContactID)
+	closeID := labelContact(t, ctx, "close", ctx.contactID)
+
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0, nil)
+	if err != nil {
+		t.Fatalf("GetVaultGraph: %v", err)
+	}
+
+	byKey := map[string]map[string]int{}
+	for _, facet := range graph.Facets {
+		counts := map[string]int{}
+		for _, value := range facet.Values {
+			counts[value.Value] = value.Count
+		}
+		byKey[facet.Key] = counts
+	}
+
+	if got := byKey["label"][schoolID]; got != 2 {
+		t.Errorf("school label count = %d, want 2", got)
+	}
+	if got := byKey["label"][closeID]; got != 1 {
+		t.Errorf("close label count = %d, want 1", got)
+	}
+	for _, absent := range []string{"gender", "pronoun", "religion", "company", "group"} {
+		if _, ok := byKey[absent]; ok {
+			t.Errorf("facet %q returned despite nothing carrying it", absent)
+		}
+	}
+}
+
+// The options describe what can be drawn, so a contact nothing connects to
+// should not put a value into a list that only narrows the drawing.
+func TestVaultGraphFacetsIgnoreContactsThatCannotBeDrawn(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+	loner := createGraphContact(t, ctx, "Loner")
+	lonelyID := labelContact(t, ctx, "lonely", loner)
+
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0, nil)
+	if err != nil {
+		t.Fatalf("GetVaultGraph: %v", err)
+	}
+
+	for _, facet := range graph.Facets {
+		for _, value := range facet.Values {
+			if value.Value == lonelyID {
+				t.Fatalf("facet value %q from an undrawable contact was offered", value.Label)
+			}
+		}
+	}
+}
+
+func TestVaultGraphFilterDrawsOnlyMatchingContacts(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	third := createGraphContact(t, ctx, "Third")
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+	createGraphRelationship(t, ctx, ctx.contactID, third, forwardTypeID)
+	schoolID := labelContact(t, ctx, "school", ctx.contactID, ctx.relatedContactID)
+
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0,
+		VaultGraphFilter{"label": {schoolID}})
+	if err != nil {
+		t.Fatalf("GetVaultGraph: %v", err)
+	}
+
+	drawn := map[string]struct{}{}
+	for _, node := range graph.Nodes {
+		drawn[node.ID] = struct{}{}
+	}
+	if len(drawn) != 2 {
+		t.Fatalf("drew %d contacts, want 2", len(drawn))
+	}
+	if _, ok := drawn[third]; ok {
+		t.Error("drew a contact that does not carry the filtered label")
+	}
+	if graph.FilteredOut != 1 {
+		t.Errorf("filtered_out = %d, want 1", graph.FilteredOut)
+	}
+}
+
+// Within a facet the values widen the result; across facets they narrow it.
+// Getting this backwards would make every extra selection return less, which
+// is not what a reader ticking a second box expects.
+func TestVaultGraphFilterOrsWithinAFacetAndAndsAcrossThem(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	third := createGraphContact(t, ctx, "Third")
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+	createGraphRelationship(t, ctx, ctx.contactID, third, forwardTypeID)
+
+	schoolID := labelContact(t, ctx, "school", ctx.contactID)
+	familyID := labelContact(t, ctx, "family", ctx.relatedContactID, third)
+	etonID := groupContact(t, ctx, "Eton", ctx.contactID, ctx.relatedContactID)
+
+	// Two values of one facet: everyone carrying either.
+	wide, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0,
+		VaultGraphFilter{"label": {schoolID, familyID}})
+	if err != nil {
+		t.Fatalf("GetVaultGraph (or): %v", err)
+	}
+	if len(wide.Nodes) != 3 {
+		t.Errorf("or within a facet drew %d contacts, want 3", len(wide.Nodes))
+	}
+
+	// Add a second facet: only those carrying a label *and* in the group.
+	narrow, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0,
+		VaultGraphFilter{"label": {schoolID, familyID}, "group": {etonID}})
+	if err != nil {
+		t.Fatalf("GetVaultGraph (and): %v", err)
+	}
+	if len(narrow.Nodes) != 2 {
+		t.Fatalf("and across facets drew %d contacts, want 2", len(narrow.Nodes))
+	}
+	drawn := nodeIDs(t, []string{narrow.Nodes[0].ID, narrow.Nodes[1].ID})
+	if _, ok := drawn[third]; ok {
+		t.Error("drew a contact that fails the second facet")
+	}
+}
+
+// Someone whose every relation was filtered away has nothing to show on a
+// relationship graph. Drawing them as a loose dot is the noise that isolated
+// contacts are excluded to avoid.
+func TestVaultGraphFilterDropsMatchesLeftWithoutAPartner(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+	schoolID := labelContact(t, ctx, "school", ctx.contactID)
+
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0,
+		VaultGraphFilter{"label": {schoolID}})
+	if err != nil {
+		t.Fatalf("GetVaultGraph: %v", err)
+	}
+
+	if len(graph.Nodes) != 0 {
+		t.Errorf("drew %d contacts, want none: the only match lost its partner", len(graph.Nodes))
+	}
+	// Both are reported: the one the filter rejected and the one it stranded.
+	if graph.FilteredOut != 2 {
+		t.Errorf("filtered_out = %d, want 2", graph.FilteredOut)
+	}
+	if graph.Components != 0 {
+		t.Errorf("components = %d, want 0", graph.Components)
+	}
+}
+
+// A selection must not narrow the list it was chosen from, or a reader who
+// picks one value can never see the others to pick again.
+func TestVaultGraphFacetsAreUnchangedByTheFilter(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	third := createGraphContact(t, ctx, "Third")
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+	createGraphRelationship(t, ctx, ctx.contactID, third, forwardTypeID)
+	schoolID := labelContact(t, ctx, "school", ctx.contactID, ctx.relatedContactID)
+	labelContact(t, ctx, "family", third)
+
+	unfiltered, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0, nil)
+	if err != nil {
+		t.Fatalf("GetVaultGraph (unfiltered): %v", err)
+	}
+	filtered, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0,
+		VaultGraphFilter{"label": {schoolID}})
+	if err != nil {
+		t.Fatalf("GetVaultGraph (filtered): %v", err)
+	}
+
+	if len(unfiltered.Facets) != len(filtered.Facets) {
+		t.Fatalf("facet count changed under a filter: %d then %d",
+			len(unfiltered.Facets), len(filtered.Facets))
+	}
+	for index, facet := range unfiltered.Facets {
+		other := filtered.Facets[index]
+		if facet.Key != other.Key || len(facet.Values) != len(other.Values) {
+			t.Fatalf("facet %q changed under a filter", facet.Key)
+		}
+		for valueIndex, value := range facet.Values {
+			if value != other.Values[valueIndex] {
+				t.Errorf("facet %q value %q changed under a filter", facet.Key, value.Label)
+			}
+		}
+	}
+}
+
+// Gender is the facet people ask for first, and it is also the one most often
+// left unset; it must work exactly like the rest once it is populated.
+func TestVaultGraphFiltersByGenderLikeAnyOtherFacet(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	third := createGraphContact(t, ctx, "Third")
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+	createGraphRelationship(t, ctx, ctx.contactID, third, forwardTypeID)
+	femaleID := genderContact(t, ctx, "Female", ctx.contactID, ctx.relatedContactID)
+	genderContact(t, ctx, "Male", third)
+
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0,
+		VaultGraphFilter{"gender": {femaleID}})
+	if err != nil {
+		t.Fatalf("GetVaultGraph: %v", err)
+	}
+
+	if len(graph.Nodes) != 2 {
+		t.Fatalf("drew %d contacts, want 2", len(graph.Nodes))
+	}
+	var genderFacet bool
+	for _, facet := range graph.Facets {
+		if facet.Key == "gender" {
+			genderFacet = true
+			if len(facet.Values) != 2 {
+				t.Errorf("gender facet offered %d values, want 2", len(facet.Values))
+			}
+		}
+	}
+	if !genderFacet {
+		t.Error("gender facet missing even though contacts carry one")
+	}
+}
+
+// An empty filter must be the same graph as no filter at all, so a page that
+// sends its controls unset does not quietly get a different answer.
+func TestVaultGraphEmptyFilterMatchesNoFilter(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+	labelContact(t, ctx, "school", ctx.contactID)
+
+	none, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0, nil)
+	if err != nil {
+		t.Fatalf("GetVaultGraph (nil): %v", err)
+	}
+	empty, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0,
+		VaultGraphFilter{"label": {}, "gender": {""}})
+	if err != nil {
+		t.Fatalf("GetVaultGraph (empty): %v", err)
+	}
+
+	if len(none.Nodes) != len(empty.Nodes) || none.FilteredOut != empty.FilteredOut {
+		t.Errorf("empty filter drew %d nodes / %d filtered out, no filter drew %d / %d",
+			len(empty.Nodes), empty.FilteredOut, len(none.Nodes), none.FilteredOut)
+	}
+}

--- a/server/internal/services/relationship_vault_graph_test.go
+++ b/server/internal/services/relationship_vault_graph_test.go
@@ -1,0 +1,227 @@
+package services
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/naiba/bonds/internal/dto"
+	"github.com/naiba/bonds/internal/testutil"
+)
+
+// asContactGraph lets the vault graph reuse the node and relation assertions
+// written for the single-contact graph; the two carry the same nodes and edges.
+func asContactGraph(graph *dto.VaultGraphResponse) *dto.ContactGraphResponse {
+	return &dto.ContactGraphResponse{Nodes: graph.Nodes, Edges: graph.Edges}
+}
+
+func createGraphContactInVault(t *testing.T, ctx relationshipTestCtx, vaultID, firstName string) string {
+	t.Helper()
+	contact, err := NewContactService(ctx.db).CreateContact(
+		vaultID,
+		ctx.userID,
+		dto.CreateContactRequest{FirstName: firstName},
+	)
+	if err != nil {
+		t.Fatalf("create contact %q in vault %s: %v", firstName, vaultID, err)
+	}
+	return contact.ID
+}
+
+func TestVaultGraphDrawsRelatedContactsAndCountsIsolatedOnes(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	isolated := createGraphContact(t, ctx, "Isolated")
+	alsoIsolated := createGraphContact(t, ctx, "AlsoIsolated")
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0)
+	if err != nil {
+		t.Fatalf("GetVaultGraph: %v", err)
+	}
+	if len(graph.Nodes) != 2 {
+		t.Fatalf("nodes = %d, want only the two related contacts", len(graph.Nodes))
+	}
+	for _, contactID := range []string{isolated, alsoIsolated} {
+		if graphContainsNode(asContactGraph(graph), contactID) {
+			t.Errorf("unrelated contact %s was drawn", contactID)
+		}
+	}
+	if graph.IsolatedContacts != 2 {
+		t.Errorf("isolated_contacts = %d, want 2", graph.IsolatedContacts)
+	}
+	if graph.Components != 1 {
+		t.Errorf("components = %d, want 1", graph.Components)
+	}
+	if graph.ExternalRelationships != 0 {
+		t.Errorf("external_relationships = %d, want 0", graph.ExternalRelationships)
+	}
+	if graph.Truncated {
+		t.Error("graph reported as truncated when everything fitted")
+	}
+}
+
+func TestVaultGraphCountsSeparateClustersIndependently(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	thirdContact := createGraphContact(t, ctx, "Third")
+	fourthContact := createGraphContact(t, ctx, "Fourth")
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+	createGraphRelationship(t, ctx, thirdContact, fourthContact, forwardTypeID)
+
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0)
+	if err != nil {
+		t.Fatalf("GetVaultGraph: %v", err)
+	}
+	if len(graph.Nodes) != 4 {
+		t.Fatalf("nodes = %d, want all four contacts across both clusters", len(graph.Nodes))
+	}
+	if graph.Components != 2 {
+		t.Errorf("components = %d, want the two unconnected clusters", graph.Components)
+	}
+	if graph.IsolatedContacts != 0 {
+		t.Errorf("isolated_contacts = %d, want 0", graph.IsolatedContacts)
+	}
+}
+
+// The vault graph must infer family across the whole vault, not just around one
+// person: the two siblings here are only siblings by way of a shared parent, and
+// nothing in the request names any of them as a centre.
+func TestVaultGraphInfersFamilyWithoutACentreContact(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	firstChild := ctx.contactID
+	secondChild := ctx.relatedContactID
+	parent := createGraphContact(t, ctx, "Parent")
+	grandParent := createGraphContact(t, ctx, "GrandParent")
+	parentTypeID := seededGraphRelationshipTypeID(t, ctx, relKeyParent)
+
+	createGraphRelationship(t, ctx, grandParent, parent, parentTypeID)
+	createGraphRelationship(t, ctx, parent, firstChild, parentTypeID)
+	createGraphRelationship(t, ctx, parent, secondChild, parentTypeID)
+
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0)
+	if err != nil {
+		t.Fatalf("GetVaultGraph: %v", err)
+	}
+	if len(graph.Nodes) != 4 {
+		t.Fatalf("nodes = %d, want the whole four-person lineage", len(graph.Nodes))
+	}
+	if graphRelationCount(asContactGraph(graph), firstChild, secondChild, relKindSibling, relKindSibling, true) != 1 {
+		t.Error("siblings sharing a parent were not inferred exactly once")
+	}
+	for _, child := range []string{firstChild, secondChild} {
+		if graphRelationCount(asContactGraph(graph), grandParent, child, relKindGrandParent, relKindGrandChild, true) != 1 {
+			t.Errorf("grandparent inference missing for child %s", child)
+		}
+	}
+	for _, node := range graph.Nodes {
+		if node.IsCenter {
+			t.Errorf("vault graph named contact %s as a centre", node.ID)
+		}
+	}
+}
+
+func TestVaultGraphCountsRelationshipsLeavingTheVaultWithoutDrawingThem(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	otherVault, err := NewVaultService(ctx.db).CreateVault(ctx.accountID, ctx.userID, dto.CreateVaultRequest{Name: "Other Vault"}, "en")
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	outsider := createGraphContactInVault(t, ctx, otherVault.ID, "Outsider")
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+	createGraphRelationship(t, ctx, ctx.contactID, outsider, forwardTypeID)
+
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0)
+	if err != nil {
+		t.Fatalf("GetVaultGraph: %v", err)
+	}
+	if graphContainsNode(asContactGraph(graph), outsider) {
+		t.Error("a contact from another vault was drawn on this vault's graph")
+	}
+	if len(graph.Nodes) != 2 {
+		t.Fatalf("nodes = %d, want only the two in-vault contacts", len(graph.Nodes))
+	}
+	if graph.ExternalRelationships != 1 {
+		t.Errorf("external_relationships = %d, want the one relationship leaving the vault", graph.ExternalRelationships)
+	}
+}
+
+// The limit drops whole clusters rather than cutting one in half, so a family is
+// never shown with members missing from the middle of it.
+func TestVaultGraphDropsWholeClustersAtTheNodeLimit(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	thirdContact := createGraphContact(t, ctx, "Third")
+	fourthContact := createGraphContact(t, ctx, "Fourth")
+	fifthContact := createGraphContact(t, ctx, "Fifth")
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	// A three-contact cluster and a two-contact one.
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+	createGraphRelationship(t, ctx, ctx.relatedContactID, thirdContact, forwardTypeID)
+	createGraphRelationship(t, ctx, fourthContact, fifthContact, forwardTypeID)
+
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 4)
+	if err != nil {
+		t.Fatalf("GetVaultGraph: %v", err)
+	}
+	if len(graph.Nodes) != 3 {
+		t.Fatalf("nodes = %d, want the larger cluster whole and the smaller one dropped", len(graph.Nodes))
+	}
+	if graph.Components != 1 {
+		t.Errorf("components = %d, want 1", graph.Components)
+	}
+	if !graph.Truncated {
+		t.Error("dropping a cluster was not reported as truncation")
+	}
+	for _, contactID := range []string{ctx.contactID, ctx.relatedContactID, thirdContact} {
+		if !graphContainsNode(asContactGraph(graph), contactID) {
+			t.Errorf("largest cluster is missing contact %s", contactID)
+		}
+	}
+}
+
+// A cluster bigger than the limit on its own is still returned: an oversized
+// drawing is a better answer than an empty one.
+func TestVaultGraphKeepsTheLargestClusterEvenWhenItExceedsTheLimit(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	thirdContact := createGraphContact(t, ctx, "Third")
+	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
+	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
+	createGraphRelationship(t, ctx, ctx.relatedContactID, thirdContact, forwardTypeID)
+
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 1)
+	if err != nil {
+		t.Fatalf("GetVaultGraph: %v", err)
+	}
+	if len(graph.Nodes) != 3 {
+		t.Fatalf("nodes = %d, want the whole oversized cluster", len(graph.Nodes))
+	}
+	if graph.Truncated {
+		t.Error("nothing was dropped, so the graph should not report truncation")
+	}
+}
+
+func TestVaultGraphRejectsAVaultTheUserCannotRead(t *testing.T) {
+	ctx := setupRelationshipTestFull(t)
+	strangerResp, err := NewAuthService(ctx.db, testutil.TestJWTConfig()).Register(dto.RegisterRequest{
+		FirstName: "Stranger",
+		LastName:  "User",
+		Email:     "vault-graph-stranger@example.com",
+		Password:  "password123",
+	}, "en")
+	if err != nil {
+		t.Fatalf("Register stranger: %v", err)
+	}
+	strangerVault, err := NewVaultService(ctx.db).CreateVault(
+		strangerResp.User.AccountID,
+		strangerResp.User.ID,
+		dto.CreateVaultRequest{Name: "Stranger Vault"},
+		"en",
+	)
+	if err != nil {
+		t.Fatalf("CreateVault for stranger: %v", err)
+	}
+
+	if _, err := ctx.svc.GetVaultGraph(strangerVault.ID, ctx.userID, "en", 0); !errors.Is(err, ErrVaultNotFound) {
+		t.Fatalf("GetVaultGraph on another account's vault = %v, want ErrVaultNotFound", err)
+	}
+}

--- a/server/internal/services/relationship_vault_graph_test.go
+++ b/server/internal/services/relationship_vault_graph_test.go
@@ -200,6 +200,27 @@ func TestVaultGraphKeepsTheLargestClusterEvenWhenItExceedsTheLimit(t *testing.T)
 	}
 }
 
+func TestNormalizeVaultGraphNodeLimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		input int
+		want  int
+	}{
+		{name: "default for zero", input: 0, want: defaultVaultGraphNodeLimit},
+		{name: "default for negative", input: -1, want: defaultVaultGraphNodeLimit},
+		{name: "requested value", input: 2500, want: 2500},
+		{name: "maximum", input: maxVaultGraphNodeLimit, want: maxVaultGraphNodeLimit},
+		{name: "clamped", input: maxVaultGraphNodeLimit + 1, want: maxVaultGraphNodeLimit},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeVaultGraphNodeLimit(tt.input); got != tt.want {
+				t.Fatalf("normalizeVaultGraphNodeLimit(%d) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestVaultGraphRejectsAVaultTheUserCannotRead(t *testing.T) {
 	ctx := setupRelationshipTestFull(t)
 	strangerResp, err := NewAuthService(ctx.db, testutil.TestJWTConfig()).Register(dto.RegisterRequest{

--- a/server/internal/services/relationship_vault_graph_test.go
+++ b/server/internal/services/relationship_vault_graph_test.go
@@ -34,7 +34,7 @@ func TestVaultGraphDrawsRelatedContactsAndCountsIsolatedOnes(t *testing.T) {
 	forwardTypeID, _ := createAsymmetricTypePair(t, ctx.db, ctx.accountID)
 	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
 
-	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0)
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0, nil)
 	if err != nil {
 		t.Fatalf("GetVaultGraph: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestVaultGraphCountsSeparateClustersIndependently(t *testing.T) {
 	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
 	createGraphRelationship(t, ctx, thirdContact, fourthContact, forwardTypeID)
 
-	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0)
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0, nil)
 	if err != nil {
 		t.Fatalf("GetVaultGraph: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestVaultGraphInfersFamilyWithoutACentreContact(t *testing.T) {
 	createGraphRelationship(t, ctx, parent, firstChild, parentTypeID)
 	createGraphRelationship(t, ctx, parent, secondChild, parentTypeID)
 
-	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0)
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0, nil)
 	if err != nil {
 		t.Fatalf("GetVaultGraph: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestVaultGraphCountsRelationshipsLeavingTheVaultWithoutDrawingThem(t *testi
 	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
 	createGraphRelationship(t, ctx, ctx.contactID, outsider, forwardTypeID)
 
-	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0)
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 0, nil)
 	if err != nil {
 		t.Fatalf("GetVaultGraph: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestVaultGraphDropsWholeClustersAtTheNodeLimit(t *testing.T) {
 	createGraphRelationship(t, ctx, ctx.relatedContactID, thirdContact, forwardTypeID)
 	createGraphRelationship(t, ctx, fourthContact, fifthContact, forwardTypeID)
 
-	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 4)
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 4, nil)
 	if err != nil {
 		t.Fatalf("GetVaultGraph: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestVaultGraphKeepsTheLargestClusterEvenWhenItExceedsTheLimit(t *testing.T)
 	createGraphRelationship(t, ctx, ctx.contactID, ctx.relatedContactID, forwardTypeID)
 	createGraphRelationship(t, ctx, ctx.relatedContactID, thirdContact, forwardTypeID)
 
-	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 1)
+	graph, err := ctx.svc.GetVaultGraph(ctx.vaultID, ctx.userID, "en", 1, nil)
 	if err != nil {
 		t.Fatalf("GetVaultGraph: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestVaultGraphRejectsAVaultTheUserCannotRead(t *testing.T) {
 		t.Fatalf("CreateVault for stranger: %v", err)
 	}
 
-	if _, err := ctx.svc.GetVaultGraph(strangerVault.ID, ctx.userID, "en", 0); !errors.Is(err, ErrVaultNotFound) {
+	if _, err := ctx.svc.GetVaultGraph(strangerVault.ID, ctx.userID, "en", 0, nil); !errors.Is(err, ErrVaultNotFound) {
 		t.Fatalf("GetVaultGraph on another account's vault = %v, want ErrVaultNotFound", err)
 	}
 }

--- a/server/internal/testutil/testutil.go
+++ b/server/internal/testutil/testutil.go
@@ -1,18 +1,69 @@
 package testutil
 
 import (
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/naiba/bonds/internal/config"
 	"github.com/naiba/bonds/internal/database"
+	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
 
+// PostgresDSNEnv, when set, runs the suite against PostgreSQL instead of
+// SQLite so dialect-specific behaviour is exercised on both databases the
+// project supports. Each test gets its own schema, dropped on cleanup, so
+// tests stay independent and can run in parallel.
+const PostgresDSNEnv = "BONDS_TEST_POSTGRES_DSN"
+
+var pgSchemaSeq atomic.Uint64
+
 func SetupTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
+	if dsn := os.Getenv(PostgresDSNEnv); dsn != "" {
+		return setupPostgresTestDB(t, dsn)
+	}
 	return setupSQLiteTestDB(t, true)
+}
+
+// setupPostgresTestDB gives each test an isolated schema on one server, which
+// is far quicker than creating a database per test and leaves nothing behind.
+func setupPostgresTestDB(t *testing.T, dsn string) *gorm.DB {
+	t.Helper()
+	schema := fmt.Sprintf("bonds_test_%d_%d", os.Getpid(), pgSchemaSeq.Add(1))
+	admin, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("Failed to connect to PostgreSQL test database: %v", err)
+	}
+	if err := admin.Exec("CREATE SCHEMA " + schema).Error; err != nil {
+		t.Fatalf("Failed to create test schema %s: %v", schema, err)
+	}
+	db, err := gorm.Open(postgres.Open(withSearchPath(dsn, schema)), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("Failed to connect to test schema %s: %v", schema, err)
+	}
+	t.Cleanup(func() {
+		admin.Exec("DROP SCHEMA IF EXISTS " + schema + " CASCADE")
+		if sqlDB, err := db.DB(); err == nil {
+			sqlDB.Close()
+		}
+		if sqlDB, err := admin.DB(); err == nil {
+			sqlDB.Close()
+		}
+	})
+	if err := database.AutoMigrate(db); err != nil {
+		t.Fatalf("Failed to migrate PostgreSQL test database: %v", err)
+	}
+	return db
 }
 
 // SetupTestDBWithFKConstraints creates a test DB with foreign-key constraints
@@ -28,6 +79,20 @@ func SetupTestDBWithFKConstraints(t *testing.T) *gorm.DB {
 		t.Fatalf("Failed to enable foreign keys: %v", err)
 	}
 	return db
+}
+
+// withSearchPath pins a DSN to one schema. libpq accepts two DSN spellings and
+// they take parameters differently: a URL takes a query parameter, a
+// keyword/value string takes another space-separated pair.
+func withSearchPath(dsn, schema string) string {
+	if strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") {
+		sep := "?"
+		if strings.Contains(dsn, "?") {
+			sep = "&"
+		}
+		return dsn + sep + "search_path=" + schema
+	}
+	return dsn + " search_path=" + schema
 }
 
 func setupSQLiteTestDB(t *testing.T, disableFKConstraintMigration bool) *gorm.DB {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,6 +36,7 @@ const VaultFiles = lazy(() => import("@/pages/vault/VaultFiles"));
 const VaultCalendar = lazy(() => import("@/pages/vault/VaultCalendar"));
 const VaultReports = lazy(() => import("@/pages/vault/VaultReports"));
 const VaultFeed = lazy(() => import("@/pages/vault/VaultFeed"));
+const VaultGraph = lazy(() => import("@/pages/vault/VaultGraph"));
 const VaultSettings = lazy(() => import("@/pages/vault/VaultSettings"));
 const VaultReminders = lazy(() => import("@/pages/vault/VaultReminders"));
 const DavSubscriptions = lazy(() => import("@/pages/vault/DavSubscriptions"));
@@ -183,6 +184,7 @@ export default function App() {
               <Route path="/vaults/:id/tasks" element={<VaultTasks />} />
               <Route path="/vaults/:id/files" element={<VaultFiles />} />
               <Route path="/vaults/:id/calendar" element={<VaultCalendar />} />
+              <Route path="/vaults/:id/graph" element={<VaultGraph />} />
               <Route path="/vaults/:id/reports" element={<VaultReports />} />
               <Route path="/vaults/:id/feed" element={<VaultFeed />} />
               <Route

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -13,6 +13,7 @@ import {
 import {
   SettingOutlined,
   TeamOutlined,
+  ShareAltOutlined,
   LogoutOutlined,
   UserOutlined,
   CalendarOutlined,
@@ -98,6 +99,7 @@ export default function Layout() {
         [
           { key: `/vaults/${vaultId}`, icon: <DashboardOutlined />, label: t("nav.dashboard") },
           { key: `/vaults/${vaultId}/contacts`, icon: <TeamOutlined />, label: t("nav.contacts") },
+          { key: `/vaults/${vaultId}/graph`, icon: <ShareAltOutlined />, label: t("nav.graph") },
         ],
         // Content
         [

--- a/web/src/components/NetworkGraph.tsx
+++ b/web/src/components/NetworkGraph.tsx
@@ -6,7 +6,10 @@ import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import { httpClient } from "@/api";
 import type { ContactGraphRelation } from "@/api";
-import { networkGraphQueryKey } from "@/components/networkGraphQueryKey";
+import {
+  networkGraphQueryKey,
+  vaultGraphQueryKey,
+} from "@/components/networkGraphQueryKey";
 import { graphEdgeLabelForNode } from "@/components/networkGraphRelations";
 
 const { Text } = Typography;
@@ -37,12 +40,17 @@ interface KinshipResult {
 
 interface NetworkGraphProps {
   vaultId: string;
-  contactId: string;
+  /** Omit to draw the whole vault instead of one contact's component. */
+  contactId?: string;
+  height?: number;
+  emptyDescription?: string;
 }
 
 export default function NetworkGraph({
   vaultId,
   contactId,
+  height = 500,
+  emptyDescription,
 }: NetworkGraphProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -58,12 +66,18 @@ export default function NetworkGraph({
     isLoading: loading,
     isError: error,
   } = useQuery({
-    queryKey: networkGraphQueryKey({ vaultId, contactId }),
+    queryKey: contactId
+      ? networkGraphQueryKey({ vaultId, contactId })
+      : vaultGraphQueryKey(vaultId),
     queryFn: async () => {
       const res = await httpClient.instance.get<{
         success: boolean;
         data: GraphData;
-      }>(`/vaults/${vaultId}/contacts/${contactId}/relationships/graph`);
+      }>(
+        contactId
+          ? `/vaults/${vaultId}/contacts/${contactId}/relationships/graph`
+          : `/vaults/${vaultId}/relationships/graph`,
+      );
       const data = res.data?.data ?? res.data;
       if (data && "nodes" in data && "edges" in data) {
         return data;
@@ -113,7 +127,6 @@ export default function NetworkGraph({
 
     const container = containerRef.current;
     const width = container.clientWidth;
-    const height = 500;
     const isMobile = width < 600;
 
     const svg = d3.select(svgRef.current);
@@ -346,6 +359,7 @@ export default function NetworkGraph({
     token.colorInfo,
     navigate,
     vaultId,
+    height,
     getNodeId,
     fetchKinship,
   ]);
@@ -423,7 +437,13 @@ export default function NetworkGraph({
   }
 
   if (error || !graphData || !graphData.nodes?.length) {
-    return <Empty description={t("modules.relationships.graph_empty")} />;
+    return (
+      <Empty
+        description={
+          emptyDescription ?? t("modules.relationships.graph_empty")
+        }
+      />
+    );
   }
 
   return (
@@ -432,7 +452,7 @@ export default function NetworkGraph({
         ref={svgRef}
         style={{
           width: "100%",
-          height: 500,
+          height,
           background: token.colorBgContainer,
           borderRadius: token.borderRadiusLG,
           border: `1px solid ${token.colorBorderSecondary}`,

--- a/web/src/components/NetworkGraph.tsx
+++ b/web/src/components/NetworkGraph.tsx
@@ -52,7 +52,22 @@ interface NetworkGraphProps {
   emptyDescription?: string;
 }
 
-export default function NetworkGraph({
+export default function NetworkGraph(props: NetworkGraphProps) {
+  const identity = props.contactId
+    ? networkGraphQueryKey({
+        vaultId: props.vaultId,
+        contactId: props.contactId,
+      })
+    : vaultGraphQueryKey(props.vaultId, props.limit, props.filters);
+
+  // A different query represents a different canvas. Remounting prevents
+  // selected contacts and a completed kinship calculation from leaking into a
+  // filtered or differently-truncated graph, while TanStack Query still reuses
+  // the cached response for this identity.
+  return <NetworkGraphCanvas key={JSON.stringify(identity)} {...props} />;
+}
+
+function NetworkGraphCanvas({
   vaultId,
   contactId,
   limit = 0,

--- a/web/src/components/NetworkGraph.tsx
+++ b/web/src/components/NetworkGraph.tsx
@@ -9,6 +9,7 @@ import type { ContactGraphRelation } from "@/api";
 import {
   networkGraphQueryKey,
   vaultGraphQueryKey,
+  vaultGraphURL,
 } from "@/components/networkGraphQueryKey";
 import { graphEdgeLabelForNode } from "@/components/networkGraphRelations";
 
@@ -42,6 +43,8 @@ interface NetworkGraphProps {
   vaultId: string;
   /** Omit to draw the whole vault instead of one contact's component. */
   contactId?: string;
+  /** Vault mode only: maximum nodes to draw. 0 leaves it to the server. */
+  limit?: number;
   height?: number;
   emptyDescription?: string;
 }
@@ -49,6 +52,7 @@ interface NetworkGraphProps {
 export default function NetworkGraph({
   vaultId,
   contactId,
+  limit = 0,
   height = 500,
   emptyDescription,
 }: NetworkGraphProps) {
@@ -68,7 +72,7 @@ export default function NetworkGraph({
   } = useQuery({
     queryKey: contactId
       ? networkGraphQueryKey({ vaultId, contactId })
-      : vaultGraphQueryKey(vaultId),
+      : vaultGraphQueryKey(vaultId, limit),
     queryFn: async () => {
       const res = await httpClient.instance.get<{
         success: boolean;
@@ -76,7 +80,7 @@ export default function NetworkGraph({
       }>(
         contactId
           ? `/vaults/${vaultId}/contacts/${contactId}/relationships/graph`
-          : `/vaults/${vaultId}/relationships/graph`,
+          : vaultGraphURL(vaultId, limit),
       );
       const data = res.data?.data ?? res.data;
       if (data && "nodes" in data && "edges" in data) {

--- a/web/src/components/NetworkGraph.tsx
+++ b/web/src/components/NetworkGraph.tsx
@@ -11,6 +11,7 @@ import {
   vaultGraphQueryKey,
   vaultGraphURL,
 } from "@/components/networkGraphQueryKey";
+import type { VaultGraphFilters } from "@/components/networkGraphQueryKey";
 import { graphEdgeLabelForNode } from "@/components/networkGraphRelations";
 
 const { Text } = Typography;
@@ -45,6 +46,8 @@ interface NetworkGraphProps {
   contactId?: string;
   /** Vault mode only: maximum nodes to draw. 0 leaves it to the server. */
   limit?: number;
+  /** Vault mode only: facet selections narrowing which contacts are drawn. */
+  filters?: VaultGraphFilters;
   height?: number;
   emptyDescription?: string;
 }
@@ -53,6 +56,7 @@ export default function NetworkGraph({
   vaultId,
   contactId,
   limit = 0,
+  filters,
   height = 500,
   emptyDescription,
 }: NetworkGraphProps) {
@@ -72,7 +76,7 @@ export default function NetworkGraph({
   } = useQuery({
     queryKey: contactId
       ? networkGraphQueryKey({ vaultId, contactId })
-      : vaultGraphQueryKey(vaultId, limit),
+      : vaultGraphQueryKey(vaultId, limit, filters),
     queryFn: async () => {
       const res = await httpClient.instance.get<{
         success: boolean;
@@ -80,7 +84,7 @@ export default function NetworkGraph({
       }>(
         contactId
           ? `/vaults/${vaultId}/contacts/${contactId}/relationships/graph`
-          : vaultGraphURL(vaultId, limit),
+          : vaultGraphURL(vaultId, limit, filters),
       );
       const data = res.data?.data ?? res.data;
       if (data && "nodes" in data && "edges" in data) {
@@ -443,9 +447,7 @@ export default function NetworkGraph({
   if (error || !graphData || !graphData.nodes?.length) {
     return (
       <Empty
-        description={
-          emptyDescription ?? t("modules.relationships.graph_empty")
-        }
+        description={emptyDescription ?? t("modules.relationships.graph_empty")}
       />
     );
   }

--- a/web/src/components/networkGraphQueryKey.ts
+++ b/web/src/components/networkGraphQueryKey.ts
@@ -21,22 +21,68 @@ export function networkGraphQueryKey({
   return ["vaults", vaultId, "contacts", contactId, "graph"];
 }
 
-export type VaultGraphQueryKey = readonly ["vaults", string, "graph", number];
+/** Facet selections, keyed by facet: {label: ["3"], group: ["12", "14"]}. */
+export type VaultGraphFilters = Readonly<Record<string, readonly string[]>>;
+
+// One canonical string for a set of selections, so the same filter chosen in a
+// different order is the same query. Both the cache key and the request are
+// built from it, which is what stops the page and the canvas from disagreeing
+// about which graph they are looking at.
+function canonicalVaultGraphFilters(filters: VaultGraphFilters): string {
+  return Object.entries(filters)
+    .map(
+      ([key, values]) =>
+        [key, [...values].filter(Boolean).sort()] as [string, string[]],
+    )
+    .filter(([, values]) => values.length > 0)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(
+      ([key, values]) =>
+        `${key}=${values.map((value) => encodeURIComponent(value)).join(",")}`,
+    )
+    .join("&");
+}
+
+export type VaultGraphQueryKey = readonly [
+  "vaults",
+  string,
+  "graph",
+  number,
+  string,
+];
 
 // The vault graph is keyed separately from the per-contact graphs so that the
 // page and the canvas share one fetch, and so contact-level invalidation does
-// not have to know about it. The limit is part of the key because raising it
-// asks the server for a different graph, not a bigger rendering of this one.
+// not have to know about it. The limit and the filter are part of the key
+// because changing either asks the server for a different graph, not a
+// different rendering of this one.
 export function vaultGraphQueryKey(
   vaultId: string,
   limit = 0,
+  filters: VaultGraphFilters = {},
 ): VaultGraphQueryKey {
-  return ["vaults", vaultId, "graph", limit];
+  return [
+    "vaults",
+    vaultId,
+    "graph",
+    limit,
+    canonicalVaultGraphFilters(filters),
+  ];
 }
 
-export function vaultGraphURL(vaultId: string, limit = 0): string {
+export function vaultGraphURL(
+  vaultId: string,
+  limit = 0,
+  filters: VaultGraphFilters = {},
+): string {
   const path = `/vaults/${vaultId}/relationships/graph`;
-  return limit > 0 ? `${path}?limit=${limit}` : path;
+  const query = [
+    ...(limit > 0 ? [`limit=${limit}`] : []),
+    ...(canonicalVaultGraphFilters(filters)
+      ? [canonicalVaultGraphFilters(filters)]
+      : []),
+  ];
+  return query.length > 0 ? `${path}?${query.join("&")}` : path;
 }
 
 export function exactNetworkGraphInvalidationFilter(

--- a/web/src/components/networkGraphQueryKey.ts
+++ b/web/src/components/networkGraphQueryKey.ts
@@ -21,6 +21,15 @@ export function networkGraphQueryKey({
   return ["vaults", vaultId, "contacts", contactId, "graph"];
 }
 
+export type VaultGraphQueryKey = readonly ["vaults", string, "graph"];
+
+// The vault graph is keyed separately from the per-contact graphs so that the
+// page and the canvas share one fetch, and so contact-level invalidation does
+// not have to know about it.
+export function vaultGraphQueryKey(vaultId: string): VaultGraphQueryKey {
+  return ["vaults", vaultId, "graph"];
+}
+
 export function exactNetworkGraphInvalidationFilter(
   queryKey: NetworkGraphQueryKey,
 ) {

--- a/web/src/components/networkGraphQueryKey.ts
+++ b/web/src/components/networkGraphQueryKey.ts
@@ -21,13 +21,22 @@ export function networkGraphQueryKey({
   return ["vaults", vaultId, "contacts", contactId, "graph"];
 }
 
-export type VaultGraphQueryKey = readonly ["vaults", string, "graph"];
+export type VaultGraphQueryKey = readonly ["vaults", string, "graph", number];
 
 // The vault graph is keyed separately from the per-contact graphs so that the
 // page and the canvas share one fetch, and so contact-level invalidation does
-// not have to know about it.
-export function vaultGraphQueryKey(vaultId: string): VaultGraphQueryKey {
-  return ["vaults", vaultId, "graph"];
+// not have to know about it. The limit is part of the key because raising it
+// asks the server for a different graph, not a bigger rendering of this one.
+export function vaultGraphQueryKey(
+  vaultId: string,
+  limit = 0,
+): VaultGraphQueryKey {
+  return ["vaults", vaultId, "graph", limit];
+}
+
+export function vaultGraphURL(vaultId: string, limit = 0): string {
+  const path = `/vaults/${vaultId}/relationships/graph`;
+  return limit > 0 ? `${path}?limit=${limit}` : path;
 }
 
 export function exactNetworkGraphInvalidationFilter(

--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -306,6 +306,8 @@
       "title": "Beziehungsgraph",
       "description": "Alle Personen in diesem Tresor, die mit einer anderen Person darin verbunden sind.",
       "empty": "In diesem Tresor stehen noch keine zwei Kontakte in Beziehung",
+      "limitLabel": "Darstellen bis zu",
+      "limitOption": "{{count}} Kontakte",
       "drawn": "{{count}} Kontakte dargestellt",
       "clusters": "{{count}} getrennte Gruppen",
       "isolated": "{{count}} nicht dargestellt, ohne Beziehung innerhalb dieses Tresors",

--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -49,6 +49,7 @@
     "vault": "Tresor",
     "dashboard": "Dashboard",
     "contacts": "Kontakte",
+    "graph": "Beziehungsgraph",
     "journal": "Journal",
     "groups": "Gruppen",
     "calendar": "Kalender",
@@ -300,6 +301,16 @@
       "col_calendar": "Kalender",
       "col_mood": "Stimmung",
       "contacts_in": "Kontakte in {{location}}"
+    },
+    "graph": {
+      "title": "Beziehungsgraph",
+      "description": "Alle Personen in diesem Tresor, die mit einer anderen Person darin verbunden sind.",
+      "empty": "In diesem Tresor stehen noch keine zwei Kontakte in Beziehung",
+      "drawn": "{{count}} Kontakte dargestellt",
+      "clusters": "{{count}} getrennte Gruppen",
+      "isolated": "{{count}} nicht dargestellt, ohne Beziehung innerhalb dieses Tresors",
+      "external": "{{count}} Beziehungen führen aus diesem Tresor hinaus",
+      "truncated": "Zu groß für eine vollständige Darstellung; die kleinsten Gruppen wurden ausgelassen"
     },
     "journals": {
       "title": "Journale",

--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -306,10 +306,21 @@
       "title": "Beziehungsgraph",
       "description": "Alle Personen in diesem Tresor, die mit einer anderen Person darin verbunden sind.",
       "empty": "In diesem Tresor stehen noch keine zwei Kontakte in Beziehung",
+      "emptyFiltered": "Keine zwei Kontakte entsprechen diesem Filter und stehen zugleich in Beziehung",
       "limitLabel": "Darstellen bis zu",
       "limitOption": "{{count}} Kontakte",
+      "clearFilters": "Filter zurücksetzen",
+      "facet": {
+        "gender": "Geschlecht",
+        "pronoun": "Pronomen",
+        "religion": "Religion",
+        "company": "Unternehmen",
+        "label": "Labels",
+        "group": "Gruppen"
+      },
       "drawn": "{{count}} Kontakte dargestellt",
       "clusters": "{{count}} getrennte Gruppen",
+      "filteredOut": "{{count}} herausgefiltert",
       "isolated": "{{count}} nicht dargestellt, ohne Beziehung innerhalb dieses Tresors",
       "external": "{{count}} Beziehungen führen aus diesem Tresor hinaus",
       "truncated": "Zu groß für eine vollständige Darstellung; die kleinsten Gruppen wurden ausgelassen"

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -49,6 +49,7 @@
     "vault": "Vault",
     "dashboard": "Dashboard",
     "contacts": "Contacts",
+    "graph": "Relationship Graph",
     "journal": "Journal",
     "groups": "Groups",
     "calendar": "Calendar",
@@ -300,6 +301,16 @@
       "col_calendar": "Calendar",
       "col_mood": "Mood",
       "contacts_in": "Contacts in {{location}}"
+    },
+    "graph": {
+      "title": "Relationship Graph",
+      "description": "Everyone in this vault who is connected to someone else in it.",
+      "empty": "No two contacts in this vault are related yet",
+      "drawn": "{{count}} contacts drawn",
+      "clusters": "{{count}} separate clusters",
+      "isolated": "{{count}} not shown, with no relationship inside this vault",
+      "external": "{{count}} relationships lead outside this vault",
+      "truncated": "Too large to draw in full; the smallest clusters were left out"
     },
     "journals": {
       "title": "Journals",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -306,6 +306,8 @@
       "title": "Relationship Graph",
       "description": "Everyone in this vault who is connected to someone else in it.",
       "empty": "No two contacts in this vault are related yet",
+      "limitLabel": "Draw up to",
+      "limitOption": "{{count}} contacts",
       "drawn": "{{count}} contacts drawn",
       "clusters": "{{count}} separate clusters",
       "isolated": "{{count}} not shown, with no relationship inside this vault",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -306,10 +306,21 @@
       "title": "Relationship Graph",
       "description": "Everyone in this vault who is connected to someone else in it.",
       "empty": "No two contacts in this vault are related yet",
+      "emptyFiltered": "No two contacts match this filter and each other",
       "limitLabel": "Draw up to",
       "limitOption": "{{count}} contacts",
+      "clearFilters": "Clear filters",
+      "facet": {
+        "gender": "Gender",
+        "pronoun": "Pronouns",
+        "religion": "Religion",
+        "company": "Company",
+        "label": "Labels",
+        "group": "Groups"
+      },
       "drawn": "{{count}} contacts drawn",
       "clusters": "{{count}} separate clusters",
+      "filteredOut": "{{count}} filtered out",
       "isolated": "{{count}} not shown, with no relationship inside this vault",
       "external": "{{count}} relationships lead outside this vault",
       "truncated": "Too large to draw in full; the smallest clusters were left out"

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -49,6 +49,7 @@
     "vault": "Bóveda",
     "dashboard": "Panel de control",
     "contacts": "Contactos",
+    "graph": "Gráfico de relaciones",
     "journal": "Diario",
     "groups": "Grupos",
     "calendar": "Calendario",
@@ -300,6 +301,16 @@
       "col_calendar": "Calendario",
       "col_mood": "Ánimo",
       "contacts_in": "Contactos en {{location}}"
+    },
+    "graph": {
+      "title": "Gráfico de relaciones",
+      "description": "Todas las personas de esta bóveda conectadas con otra persona de la misma.",
+      "empty": "Todavía no hay dos contactos relacionados en esta bóveda",
+      "drawn": "{{count}} contactos dibujados",
+      "clusters": "{{count}} grupos separados",
+      "isolated": "{{count}} sin mostrar, sin ninguna relación dentro de esta bóveda",
+      "external": "{{count}} relaciones salen de esta bóveda",
+      "truncated": "Demasiado grande para dibujarlo entero; se omitieron los grupos más pequeños"
     },
     "journals": {
       "title": "Diarios",

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -306,6 +306,8 @@
       "title": "Gráfico de relaciones",
       "description": "Todas las personas de esta bóveda conectadas con otra persona de la misma.",
       "empty": "Todavía no hay dos contactos relacionados en esta bóveda",
+      "limitLabel": "Dibujar hasta",
+      "limitOption": "{{count}} contactos",
       "drawn": "{{count}} contactos dibujados",
       "clusters": "{{count}} grupos separados",
       "isolated": "{{count}} sin mostrar, sin ninguna relación dentro de esta bóveda",

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -306,10 +306,21 @@
       "title": "Gráfico de relaciones",
       "description": "Todas las personas de esta bóveda conectadas con otra persona de la misma.",
       "empty": "Todavía no hay dos contactos relacionados en esta bóveda",
+      "emptyFiltered": "No hay dos contactos que coincidan con este filtro y estén relacionados",
       "limitLabel": "Dibujar hasta",
       "limitOption": "{{count}} contactos",
+      "clearFilters": "Borrar filtros",
+      "facet": {
+        "gender": "Género",
+        "pronoun": "Pronombres",
+        "religion": "Religión",
+        "company": "Empresa",
+        "label": "Etiquetas",
+        "group": "Grupos"
+      },
       "drawn": "{{count}} contactos dibujados",
       "clusters": "{{count}} grupos separados",
+      "filteredOut": "{{count}} excluidos por el filtro",
       "isolated": "{{count}} sin mostrar, sin ninguna relación dentro de esta bóveda",
       "external": "{{count}} relaciones salen de esta bóveda",
       "truncated": "Demasiado grande para dibujarlo entero; se omitieron los grupos más pequeños"

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -306,6 +306,8 @@
       "title": "Graphe des relations",
       "description": "Toutes les personnes de ce coffre reliées à une autre personne du coffre.",
       "empty": "Aucun contact de ce coffre n'est encore lié à un autre",
+      "limitLabel": "Afficher jusqu'à",
+      "limitOption": "{{count}} contacts",
       "drawn": "{{count}} contacts affichés",
       "clusters": "{{count}} groupes distincts",
       "isolated": "{{count}} non affichés, sans relation dans ce coffre",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -49,6 +49,7 @@
     "vault": "Coffre",
     "dashboard": "Tableau de bord",
     "contacts": "Contacts",
+    "graph": "Graphe des relations",
     "journal": "Journal",
     "groups": "Groupes",
     "calendar": "Calendrier",
@@ -300,6 +301,16 @@
       "col_calendar": "Calendrier",
       "col_mood": "Humeur",
       "contacts_in": "Contacts aux {{location}}"
+    },
+    "graph": {
+      "title": "Graphe des relations",
+      "description": "Toutes les personnes de ce coffre reliées à une autre personne du coffre.",
+      "empty": "Aucun contact de ce coffre n'est encore lié à un autre",
+      "drawn": "{{count}} contacts affichés",
+      "clusters": "{{count}} groupes distincts",
+      "isolated": "{{count}} non affichés, sans relation dans ce coffre",
+      "external": "{{count}} relations mènent hors de ce coffre",
+      "truncated": "Trop grand pour être affiché en entier ; les plus petits groupes ont été omis"
     },
     "journals": {
       "title": "Journaux",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -306,10 +306,21 @@
       "title": "Graphe des relations",
       "description": "Toutes les personnes de ce coffre reliées à une autre personne du coffre.",
       "empty": "Aucun contact de ce coffre n'est encore lié à un autre",
+      "emptyFiltered": "Aucun couple de contacts ne correspond à ce filtre tout en étant lié",
       "limitLabel": "Afficher jusqu'à",
       "limitOption": "{{count}} contacts",
+      "clearFilters": "Effacer les filtres",
+      "facet": {
+        "gender": "Genre",
+        "pronoun": "Pronoms",
+        "religion": "Religion",
+        "company": "Entreprise",
+        "label": "Étiquettes",
+        "group": "Groupes"
+      },
       "drawn": "{{count}} contacts affichés",
       "clusters": "{{count}} groupes distincts",
+      "filteredOut": "{{count}} exclus par le filtre",
       "isolated": "{{count}} non affichés, sans relation dans ce coffre",
       "external": "{{count}} relations mènent hors de ce coffre",
       "truncated": "Trop grand pour être affiché en entier ; les plus petits groupes ont été omis"

--- a/web/src/locales/pt-BR.json
+++ b/web/src/locales/pt-BR.json
@@ -306,6 +306,8 @@
       "title": "Gráfico de relações",
       "description": "Todas as pessoas deste cofre que estão ligadas a outra pessoa dele.",
       "empty": "Nenhum par de contatos deste cofre tem relação ainda",
+      "limitLabel": "Desenhar até",
+      "limitOption": "{{count}} contatos",
       "drawn": "{{count}} contatos desenhados",
       "clusters": "{{count}} grupos separados",
       "isolated": "{{count}} não exibidos, sem relação dentro deste cofre",

--- a/web/src/locales/pt-BR.json
+++ b/web/src/locales/pt-BR.json
@@ -306,10 +306,21 @@
       "title": "Gráfico de relações",
       "description": "Todas as pessoas deste cofre que estão ligadas a outra pessoa dele.",
       "empty": "Nenhum par de contatos deste cofre tem relação ainda",
+      "emptyFiltered": "Não há dois contatos que atendam a este filtro e estejam relacionados",
       "limitLabel": "Desenhar até",
       "limitOption": "{{count}} contatos",
+      "clearFilters": "Limpar filtros",
+      "facet": {
+        "gender": "Gênero",
+        "pronoun": "Pronomes",
+        "religion": "Religião",
+        "company": "Empresa",
+        "label": "Etiquetas",
+        "group": "Grupos"
+      },
       "drawn": "{{count}} contatos desenhados",
       "clusters": "{{count}} grupos separados",
+      "filteredOut": "{{count}} excluídos pelo filtro",
       "isolated": "{{count}} não exibidos, sem relação dentro deste cofre",
       "external": "{{count}} relações levam para fora deste cofre",
       "truncated": "Grande demais para desenhar por inteiro; os menores grupos ficaram de fora"

--- a/web/src/locales/pt-BR.json
+++ b/web/src/locales/pt-BR.json
@@ -49,6 +49,7 @@
     "vault": "Cofre",
     "dashboard": "Painel",
     "contacts": "Contatos",
+    "graph": "Gráfico de relações",
     "journal": "Diário",
     "groups": "Grupos",
     "calendar": "Calendário",
@@ -300,6 +301,16 @@
       "col_calendar": "Calendário",
       "col_mood": "Humor",
       "contacts_in": "Contatos em {{location}}"
+    },
+    "graph": {
+      "title": "Gráfico de relações",
+      "description": "Todas as pessoas deste cofre que estão ligadas a outra pessoa dele.",
+      "empty": "Nenhum par de contatos deste cofre tem relação ainda",
+      "drawn": "{{count}} contatos desenhados",
+      "clusters": "{{count}} grupos separados",
+      "isolated": "{{count}} não exibidos, sem relação dentro deste cofre",
+      "external": "{{count}} relações levam para fora deste cofre",
+      "truncated": "Grande demais para desenhar por inteiro; os menores grupos ficaram de fora"
     },
     "journals": {
       "title": "Diários",

--- a/web/src/locales/pt-PT.json
+++ b/web/src/locales/pt-PT.json
@@ -306,10 +306,21 @@
       "title": "Gráfico de relações",
       "description": "Todas as pessoas deste cofre que estão ligadas a outra pessoa dele.",
       "empty": "Nenhum par de contactos deste cofre tem relação ainda",
+      "emptyFiltered": "Não há dois contactos que correspondam a este filtro e estejam relacionados",
       "limitLabel": "Desenhar até",
       "limitOption": "{{count}} contactos",
+      "clearFilters": "Limpar filtros",
+      "facet": {
+        "gender": "Género",
+        "pronoun": "Pronomes",
+        "religion": "Religião",
+        "company": "Empresa",
+        "label": "Etiquetas",
+        "group": "Grupos"
+      },
       "drawn": "{{count}} contactos desenhados",
       "clusters": "{{count}} grupos separados",
+      "filteredOut": "{{count}} excluídos pelo filtro",
       "isolated": "{{count}} não apresentados, sem relação dentro deste cofre",
       "external": "{{count}} relações levam para fora deste cofre",
       "truncated": "Demasiado grande para desenhar por inteiro; os grupos mais pequenos ficaram de fora"

--- a/web/src/locales/pt-PT.json
+++ b/web/src/locales/pt-PT.json
@@ -49,6 +49,7 @@
     "vault": "Cofre",
     "dashboard": "Painel",
     "contacts": "Contactos",
+    "graph": "Gráfico de relações",
     "journal": "Diário",
     "groups": "Grupos",
     "calendar": "Calendário",
@@ -300,6 +301,16 @@
       "col_calendar": "Calendário",
       "col_mood": "Humor",
       "contacts_in": "Contactos em {{location}}"
+    },
+    "graph": {
+      "title": "Gráfico de relações",
+      "description": "Todas as pessoas deste cofre que estão ligadas a outra pessoa dele.",
+      "empty": "Nenhum par de contactos deste cofre tem relação ainda",
+      "drawn": "{{count}} contactos desenhados",
+      "clusters": "{{count}} grupos separados",
+      "isolated": "{{count}} não apresentados, sem relação dentro deste cofre",
+      "external": "{{count}} relações levam para fora deste cofre",
+      "truncated": "Demasiado grande para desenhar por inteiro; os grupos mais pequenos ficaram de fora"
     },
     "journals": {
       "title": "Diários",

--- a/web/src/locales/pt-PT.json
+++ b/web/src/locales/pt-PT.json
@@ -306,6 +306,8 @@
       "title": "Gráfico de relações",
       "description": "Todas as pessoas deste cofre que estão ligadas a outra pessoa dele.",
       "empty": "Nenhum par de contactos deste cofre tem relação ainda",
+      "limitLabel": "Desenhar até",
+      "limitOption": "{{count}} contactos",
       "drawn": "{{count}} contactos desenhados",
       "clusters": "{{count}} grupos separados",
       "isolated": "{{count}} não apresentados, sem relação dentro deste cofre",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -306,10 +306,21 @@
       "title": "关系图谱",
       "description": "此保险库中与库内其他人存在关联的所有联系人。",
       "empty": "此保险库中尚无相互关联的联系人",
+      "emptyFiltered": "没有两个符合此筛选条件的联系人彼此相关",
       "limitLabel": "最多绘制",
       "limitOption": "{{count}} 位联系人",
+      "clearFilters": "清除筛选",
+      "facet": {
+        "gender": "性别",
+        "pronoun": "人称代词",
+        "religion": "宗教信仰",
+        "company": "公司",
+        "label": "标签",
+        "group": "群组"
+      },
       "drawn": "已绘制 {{count}} 位联系人",
       "clusters": "{{count}} 个独立群组",
+      "filteredOut": "已筛除 {{count}} 位",
       "isolated": "{{count}} 位未显示，在此保险库内没有关系",
       "external": "{{count}} 条关系指向此保险库之外",
       "truncated": "图谱过大，无法完整绘制，已省略最小的群组"

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -306,6 +306,8 @@
       "title": "关系图谱",
       "description": "此保险库中与库内其他人存在关联的所有联系人。",
       "empty": "此保险库中尚无相互关联的联系人",
+      "limitLabel": "最多绘制",
+      "limitOption": "{{count}} 位联系人",
       "drawn": "已绘制 {{count}} 位联系人",
       "clusters": "{{count}} 个独立群组",
       "isolated": "{{count}} 位未显示，在此保险库内没有关系",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -49,6 +49,7 @@
     "vault": "保险库",
     "dashboard": "仪表盘",
     "contacts": "联系人",
+    "graph": "关系图谱",
     "journal": "日记",
     "groups": "群组",
     "calendar": "日历",
@@ -300,6 +301,16 @@
       "col_calendar": "历法",
       "col_mood": "情绪",
       "contacts_in": "{{location}} 的联系人"
+    },
+    "graph": {
+      "title": "关系图谱",
+      "description": "此保险库中与库内其他人存在关联的所有联系人。",
+      "empty": "此保险库中尚无相互关联的联系人",
+      "drawn": "已绘制 {{count}} 位联系人",
+      "clusters": "{{count}} 个独立群组",
+      "isolated": "{{count}} 位未显示，在此保险库内没有关系",
+      "external": "{{count}} 条关系指向此保险库之外",
+      "truncated": "图谱过大，无法完整绘制，已省略最小的群组"
     },
     "journals": {
       "title": "日记本",

--- a/web/src/pages/vault/VaultGraph.tsx
+++ b/web/src/pages/vault/VaultGraph.tsx
@@ -1,0 +1,104 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { Card, Typography, Button, Space, Tag, theme } from "antd";
+import { ArrowLeftOutlined, ShareAltOutlined } from "@ant-design/icons";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { httpClient } from "@/api";
+import NetworkGraph from "@/components/NetworkGraph";
+import { vaultGraphQueryKey } from "@/components/networkGraphQueryKey";
+
+const { Title, Text } = Typography;
+
+interface VaultGraphSummary {
+  nodes?: { id: string }[];
+  components?: number;
+  isolated_contacts?: number;
+  external_relationships?: number;
+  truncated?: boolean;
+}
+
+export default function VaultGraph() {
+  const { id } = useParams<{ id: string }>();
+  const vaultId = id!;
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+
+  // Same query key as the canvas below, so the page and the drawing share one
+  // request rather than each fetching the vault graph separately.
+  const { data: summary } = useQuery({
+    queryKey: vaultGraphQueryKey(vaultId),
+    queryFn: async () => {
+      const res = await httpClient.instance.get<{
+        success: boolean;
+        data: VaultGraphSummary;
+      }>(`/vaults/${vaultId}/relationships/graph`);
+      return (res.data?.data ?? res.data) as VaultGraphSummary;
+    },
+  });
+
+  const drawnContacts = summary?.nodes?.length ?? 0;
+  const isolatedContacts = summary?.isolated_contacts ?? 0;
+  const externalRelationships = summary?.external_relationships ?? 0;
+
+  return (
+    <div style={{ maxWidth: 1100, margin: "0 auto", paddingBottom: 48 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 8,
+        }}
+      >
+        <Button
+          type="text"
+          icon={<ArrowLeftOutlined />}
+          onClick={() => navigate(`/vaults/${vaultId}`)}
+          style={{ color: token.colorTextSecondary }}
+        />
+        <ShareAltOutlined style={{ fontSize: 20, color: token.colorPrimary }} />
+        <Title level={4} style={{ margin: 0 }}>
+          {t("vault.graph.title")}
+        </Title>
+      </div>
+      <Text type="secondary" style={{ display: "block", marginBottom: 20 }}>
+        {t("vault.graph.description")}
+      </Text>
+
+      <Card styles={{ body: { paddingTop: 12 } }}>
+        <NetworkGraph
+          vaultId={vaultId}
+          height={620}
+          emptyDescription={t("vault.graph.empty")}
+        />
+
+        {/* What is not on the canvas matters as much as what is, so the counts
+            that were left out are stated rather than silently dropped. */}
+        <Space size={[8, 8]} wrap style={{ marginTop: 4 }}>
+          <Tag color="blue">
+            {t("vault.graph.drawn", { count: drawnContacts })}
+          </Tag>
+          {(summary?.components ?? 0) > 1 && (
+            <Tag>
+              {t("vault.graph.clusters", { count: summary?.components ?? 0 })}
+            </Tag>
+          )}
+          {isolatedContacts > 0 && (
+            <Tag>
+              {t("vault.graph.isolated", { count: isolatedContacts })}
+            </Tag>
+          )}
+          {externalRelationships > 0 && (
+            <Tag>
+              {t("vault.graph.external", { count: externalRelationships })}
+            </Tag>
+          )}
+          {summary?.truncated && (
+            <Tag color="orange">{t("vault.graph.truncated")}</Tag>
+          )}
+        </Space>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/pages/vault/VaultGraph.tsx
+++ b/web/src/pages/vault/VaultGraph.tsx
@@ -18,6 +18,7 @@ const { Title, Text } = Typography;
 // so the default is a legibility choice. On a large vault it can leave most of
 // the related contacts out, which is the reader's call to overrule, not ours.
 const NODE_LIMITS = [400, 1000, 2500, 5000];
+const DEFAULT_NODE_LIMIT = 1000;
 
 interface VaultGraphFacetValue {
   value: string;
@@ -46,7 +47,7 @@ export default function VaultGraph() {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const [limit, setLimit] = useState(NODE_LIMITS[0]);
+  const [limit, setLimit] = useState(DEFAULT_NODE_LIMIT);
   const [filters, setFilters] = useState<VaultGraphFilters>({});
 
   // Same query key as the canvas below, so the page and the drawing share one

--- a/web/src/pages/vault/VaultGraph.tsx
+++ b/web/src/pages/vault/VaultGraph.tsx
@@ -1,13 +1,22 @@
+import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Card, Typography, Button, Space, Tag, theme } from "antd";
+import { Card, Typography, Button, Select, Space, Tag, theme } from "antd";
 import { ArrowLeftOutlined, ShareAltOutlined } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { httpClient } from "@/api";
 import NetworkGraph from "@/components/NetworkGraph";
-import { vaultGraphQueryKey } from "@/components/networkGraphQueryKey";
+import {
+  vaultGraphQueryKey,
+  vaultGraphURL,
+} from "@/components/networkGraphQueryKey";
 
 const { Title, Text } = Typography;
+
+// A force layout stops being readable long before it stops being renderable,
+// so the default is a legibility choice. On a large vault it can leave most of
+// the related contacts out, which is the reader's call to overrule, not ours.
+const NODE_LIMITS = [400, 1000, 2500, 5000];
 
 interface VaultGraphSummary {
   nodes?: { id: string }[];
@@ -23,16 +32,17 @@ export default function VaultGraph() {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { token } = theme.useToken();
+  const [limit, setLimit] = useState(NODE_LIMITS[0]);
 
   // Same query key as the canvas below, so the page and the drawing share one
   // request rather than each fetching the vault graph separately.
   const { data: summary } = useQuery({
-    queryKey: vaultGraphQueryKey(vaultId),
+    queryKey: vaultGraphQueryKey(vaultId, limit),
     queryFn: async () => {
       const res = await httpClient.instance.get<{
         success: boolean;
         data: VaultGraphSummary;
-      }>(`/vaults/${vaultId}/relationships/graph`);
+      }>(vaultGraphURL(vaultId, limit));
       return (res.data?.data ?? res.data) as VaultGraphSummary;
     },
   });
@@ -67,8 +77,33 @@ export default function VaultGraph() {
       </Text>
 
       <Card styles={{ body: { paddingTop: 12 } }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            alignItems: "center",
+            gap: 8,
+            marginBottom: 12,
+          }}
+        >
+          <Text type="secondary" style={{ fontSize: 12 }}>
+            {t("vault.graph.limitLabel")}
+          </Text>
+          <Select
+            size="small"
+            value={limit}
+            onChange={setLimit}
+            style={{ width: 110 }}
+            options={NODE_LIMITS.map((value) => ({
+              value,
+              label: t("vault.graph.limitOption", { count: value }),
+            }))}
+          />
+        </div>
+
         <NetworkGraph
           vaultId={vaultId}
+          limit={limit}
           height={620}
           emptyDescription={t("vault.graph.empty")}
         />

--- a/web/src/pages/vault/VaultGraph.tsx
+++ b/web/src/pages/vault/VaultGraph.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Card, Typography, Button, Select, Space, Tag, theme } from "antd";
 import { ArrowLeftOutlined, ShareAltOutlined } from "@ant-design/icons";
@@ -10,6 +10,7 @@ import {
   vaultGraphQueryKey,
   vaultGraphURL,
 } from "@/components/networkGraphQueryKey";
+import type { VaultGraphFilters } from "@/components/networkGraphQueryKey";
 
 const { Title, Text } = Typography;
 
@@ -18,12 +19,25 @@ const { Title, Text } = Typography;
 // the related contacts out, which is the reader's call to overrule, not ours.
 const NODE_LIMITS = [400, 1000, 2500, 5000];
 
+interface VaultGraphFacetValue {
+  value: string;
+  label: string;
+  count: number;
+}
+
+interface VaultGraphFacet {
+  key: string;
+  values: VaultGraphFacetValue[];
+}
+
 interface VaultGraphSummary {
   nodes?: { id: string }[];
   components?: number;
   isolated_contacts?: number;
   external_relationships?: number;
   truncated?: boolean;
+  facets?: VaultGraphFacet[];
+  filtered_out?: number;
 }
 
 export default function VaultGraph() {
@@ -33,16 +47,17 @@ export default function VaultGraph() {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const [limit, setLimit] = useState(NODE_LIMITS[0]);
+  const [filters, setFilters] = useState<VaultGraphFilters>({});
 
   // Same query key as the canvas below, so the page and the drawing share one
   // request rather than each fetching the vault graph separately.
   const { data: summary } = useQuery({
-    queryKey: vaultGraphQueryKey(vaultId, limit),
+    queryKey: vaultGraphQueryKey(vaultId, limit, filters),
     queryFn: async () => {
       const res = await httpClient.instance.get<{
         success: boolean;
         data: VaultGraphSummary;
-      }>(vaultGraphURL(vaultId, limit));
+      }>(vaultGraphURL(vaultId, limit, filters));
       return (res.data?.data ?? res.data) as VaultGraphSummary;
     },
   });
@@ -50,6 +65,18 @@ export default function VaultGraph() {
   const drawnContacts = summary?.nodes?.length ?? 0;
   const isolatedContacts = summary?.isolated_contacts ?? 0;
   const externalRelationships = summary?.external_relationships ?? 0;
+  const filteredOut = summary?.filtered_out ?? 0;
+
+  // The server omits facets nothing carries, so this renders a control only
+  // where there is something to pick. On a vault where nobody has a gender set,
+  // no gender control appears — and one appears by itself once they do.
+  const facets = useMemo(() => summary?.facets ?? [], [summary?.facets]);
+  const hasSelection = Object.values(filters).some(
+    (values) => values.length > 0,
+  );
+
+  const selectFacet = (key: string, values: string[]) =>
+    setFilters((current) => ({ ...current, [key]: values }));
 
   return (
     <div style={{ maxWidth: 1100, margin: "0 auto", paddingBottom: 48 }}>
@@ -80,32 +107,65 @@ export default function VaultGraph() {
         <div
           style={{
             display: "flex",
-            justifyContent: "flex-end",
+            flexWrap: "wrap",
+            justifyContent: "space-between",
             alignItems: "center",
             gap: 8,
             marginBottom: 12,
           }}
         >
-          <Text type="secondary" style={{ fontSize: 12 }}>
-            {t("vault.graph.limitLabel")}
-          </Text>
-          <Select
-            size="small"
-            value={limit}
-            onChange={setLimit}
-            style={{ width: 110 }}
-            options={NODE_LIMITS.map((value) => ({
-              value,
-              label: t("vault.graph.limitOption", { count: value }),
-            }))}
-          />
+          <Space size={[8, 8]} wrap>
+            {facets.map((facet) => (
+              <Select
+                key={facet.key}
+                mode="multiple"
+                allowClear
+                size="small"
+                maxTagCount="responsive"
+                style={{ minWidth: 180 }}
+                value={[...(filters[facet.key] ?? [])]}
+                onChange={(values: string[]) => selectFacet(facet.key, values)}
+                placeholder={t(`vault.graph.facet.${facet.key}`)}
+                aria-label={t(`vault.graph.facet.${facet.key}`)}
+                options={facet.values.map((value) => ({
+                  value: value.value,
+                  label: `${value.label} (${value.count})`,
+                }))}
+              />
+            ))}
+            {hasSelection && (
+              <Button size="small" type="link" onClick={() => setFilters({})}>
+                {t("vault.graph.clearFilters")}
+              </Button>
+            )}
+          </Space>
+
+          <Space size={8}>
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              {t("vault.graph.limitLabel")}
+            </Text>
+            <Select
+              size="small"
+              value={limit}
+              onChange={setLimit}
+              style={{ width: 110 }}
+              aria-label={t("vault.graph.limitLabel")}
+              options={NODE_LIMITS.map((value) => ({
+                value,
+                label: t("vault.graph.limitOption", { count: value }),
+              }))}
+            />
+          </Space>
         </div>
 
         <NetworkGraph
           vaultId={vaultId}
           limit={limit}
+          filters={filters}
           height={620}
-          emptyDescription={t("vault.graph.empty")}
+          emptyDescription={t(
+            hasSelection ? "vault.graph.emptyFiltered" : "vault.graph.empty",
+          )}
         />
 
         {/* What is not on the canvas matters as much as what is, so the counts
@@ -119,10 +179,13 @@ export default function VaultGraph() {
               {t("vault.graph.clusters", { count: summary?.components ?? 0 })}
             </Tag>
           )}
-          {isolatedContacts > 0 && (
-            <Tag>
-              {t("vault.graph.isolated", { count: isolatedContacts })}
+          {filteredOut > 0 && (
+            <Tag color="purple">
+              {t("vault.graph.filteredOut", { count: filteredOut })}
             </Tag>
+          )}
+          {isolatedContacts > 0 && (
+            <Tag>{t("vault.graph.isolated", { count: isolatedContacts })}</Tag>
           )}
           {externalRelationships > 0 && (
             <Tag>

--- a/web/src/test/VaultGraph.test.tsx
+++ b/web/src/test/VaultGraph.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { App as AntApp, ConfigProvider } from "antd";
 import { MemoryRouter } from "react-router-dom";
@@ -9,6 +10,7 @@ import {
   vaultGraphQueryKey,
   vaultGraphURL,
 } from "@/components/networkGraphQueryKey";
+import type { VaultGraphFilters } from "@/components/networkGraphQueryKey";
 
 const httpMocks = vi.hoisted(() => ({ get: vi.fn() }));
 
@@ -195,6 +197,56 @@ describe("NetworkGraph in vault mode", () => {
         "/vaults/vault-1/contacts/contact-9/relationships/graph",
       ),
     );
+  });
+
+  it("clears selected nodes and kinship when the graph query changes", async () => {
+    httpMocks.get.mockImplementation((url: string) => {
+      if (url.includes("/kinship/")) {
+        return Promise.resolve({
+          data: { success: true, data: { degree: 2, path: ["a", "b"] } },
+        });
+      }
+      return Promise.resolve(graphResponse());
+    });
+
+    function Harness() {
+      const [filters, setFilters] = useState<VaultGraphFilters>({});
+      return (
+        <>
+          <button onClick={() => setFilters({ label: ["3"] })}>
+            change graph
+          </button>
+          <NetworkGraph
+            vaultId="vault-1"
+            limit={1000}
+            filters={filters}
+          />
+        </>
+      );
+    }
+
+    const { container } = renderWithProviders(<Harness />);
+    await screen.findByText("Click two nodes to calculate kinship");
+    await waitFor(() =>
+      expect(container.querySelectorAll("svg circle")).toHaveLength(2),
+    );
+
+    const circles = container.querySelectorAll("svg circle");
+    fireEvent.click(circles[0]);
+    fireEvent.click(circles[1]);
+    expect(await screen.findByText("Kinship Degree: 2")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("change graph"));
+
+    await waitFor(() =>
+      expect(httpMocks.get).toHaveBeenCalledWith(
+        "/vaults/vault-1/relationships/graph?limit=1000&label=3",
+      ),
+    );
+    expect(screen.queryByText("Kinship Degree: 2")).not.toBeInTheDocument();
+    expect(
+      await screen.findByText("Click two nodes to calculate kinship"),
+    ).toBeInTheDocument();
   });
 });
 

--- a/web/src/test/VaultGraph.test.tsx
+++ b/web/src/test/VaultGraph.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { App as AntApp, ConfigProvider } from "antd";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -68,9 +68,27 @@ describe("VaultGraph page", () => {
 
     await waitFor(() => expect(httpMocks.get).toHaveBeenCalled());
     expect(httpMocks.get).toHaveBeenCalledWith(
-      "/vaults/vault-1/relationships/graph",
+      "/vaults/vault-1/relationships/graph?limit=400",
     );
     expect(await screen.findByText("2 contacts drawn")).toBeInTheDocument();
+  });
+
+  // A vault whose largest cluster alone exceeds the default is the case this
+  // control exists for: without it the page shows a fraction and says so.
+  it("re-asks the server when the reader raises the limit", async () => {
+    httpMocks.get.mockResolvedValue(graphResponse({ truncated: true }));
+
+    renderWithProviders(<VaultGraph />);
+    await screen.findByText("2 contacts drawn");
+
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.click(await screen.findByTitle("2500 contacts"));
+
+    await waitFor(() =>
+      expect(httpMocks.get).toHaveBeenCalledWith(
+        "/vaults/vault-1/relationships/graph?limit=2500",
+      ),
+    );
   });
 
   it("accounts for the contacts and relationships it left out", async () => {
@@ -119,13 +137,18 @@ describe("VaultGraph page", () => {
     renderWithProviders(
       <>
         <VaultGraph />
-        <NetworkGraph vaultId="vault-1" />
+        <NetworkGraph vaultId="vault-1" limit={400} />
       </>,
     );
 
     await screen.findByText("2 contacts drawn");
     await waitFor(() => expect(httpMocks.get).toHaveBeenCalledTimes(1));
-    expect(vaultGraphQueryKey("vault-1")).toEqual(["vaults", "vault-1", "graph"]);
+    expect(vaultGraphQueryKey("vault-1", 400)).toEqual([
+      "vaults",
+      "vault-1",
+      "graph",
+      400,
+    ]);
   });
 });
 

--- a/web/src/test/VaultGraph.test.tsx
+++ b/web/src/test/VaultGraph.test.tsx
@@ -5,7 +5,10 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import VaultGraph from "@/pages/vault/VaultGraph";
 import NetworkGraph from "@/components/NetworkGraph";
-import { vaultGraphQueryKey } from "@/components/networkGraphQueryKey";
+import {
+  vaultGraphQueryKey,
+  vaultGraphURL,
+} from "@/components/networkGraphQueryKey";
 
 const httpMocks = vi.hoisted(() => ({ get: vi.fn() }));
 
@@ -50,6 +53,8 @@ function graphResponse(overrides: Record<string, unknown> = {}) {
         isolated_contacts: 0,
         external_relationships: 0,
         truncated: false,
+        facets: [],
+        filtered_out: 0,
         ...overrides,
       },
     },
@@ -148,6 +153,7 @@ describe("VaultGraph page", () => {
       "vault-1",
       "graph",
       400,
+      "",
     ]);
   });
 });
@@ -188,6 +194,90 @@ describe("NetworkGraph in vault mode", () => {
       expect(httpMocks.get).toHaveBeenCalledWith(
         "/vaults/vault-1/contacts/contact-9/relationships/graph",
       ),
+    );
+  });
+});
+
+// The server omits facets nothing in the vault carries, so a vault where
+// nobody has a gender set must not be given a gender control to poke at.
+describe("VaultGraph filtering", () => {
+  const withFacets = () =>
+    graphResponse({
+      facets: [
+        {
+          key: "label",
+          values: [
+            { value: "3", label: "school", count: 12 },
+            { value: "7", label: "family", count: 4 },
+          ],
+        },
+      ],
+    });
+
+  it("offers a control only for the facets the vault carries", async () => {
+    httpMocks.get.mockResolvedValue(withFacets());
+
+    renderWithProviders(<VaultGraph />);
+
+    expect(await screen.findByLabelText("Labels")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Gender")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Groups")).not.toBeInTheDocument();
+  });
+
+  it("asks the server for the narrowed graph when a value is picked", async () => {
+    httpMocks.get.mockResolvedValue(withFacets());
+
+    renderWithProviders(<VaultGraph />);
+    await screen.findByLabelText("Labels");
+
+    fireEvent.mouseDown(screen.getByLabelText("Labels"));
+    fireEvent.click(await screen.findByTitle("school (12)"));
+
+    await waitFor(() =>
+      expect(httpMocks.get).toHaveBeenCalledWith(
+        "/vaults/vault-1/relationships/graph?limit=400&label=3",
+      ),
+    );
+  });
+
+  it("accounts for the contacts the filter took off the canvas", async () => {
+    httpMocks.get.mockResolvedValue(
+      graphResponse({ facets: [], filtered_out: 9 }),
+    );
+
+    renderWithProviders(<VaultGraph />);
+
+    expect(await screen.findByText("9 filtered out")).toBeInTheDocument();
+  });
+
+  it("stays quiet about a filter that excluded nobody", async () => {
+    httpMocks.get.mockResolvedValue(graphResponse());
+
+    renderWithProviders(<VaultGraph />);
+
+    await screen.findByText("2 contacts drawn");
+    expect(screen.queryByText(/filtered out/)).not.toBeInTheDocument();
+  });
+});
+
+// Two selections made in a different order are the same graph, so they must be
+// the same cache entry and the same request.
+describe("vaultGraphQueryKey", () => {
+  it("keys a selection the same however it was ordered", () => {
+    expect(vaultGraphQueryKey("vault-1", 400, { label: ["7", "3"] })).toEqual(
+      vaultGraphQueryKey("vault-1", 400, { label: ["3", "7"] }),
+    );
+  });
+
+  it("keys different selections differently", () => {
+    expect(vaultGraphQueryKey("vault-1", 400, { label: ["3"] })).not.toEqual(
+      vaultGraphQueryKey("vault-1", 400, { group: ["3"] }),
+    );
+  });
+
+  it("drops empty selections rather than sending them", () => {
+    expect(vaultGraphURL("vault-1", 400, { label: [], group: [""] })).toBe(
+      "/vaults/vault-1/relationships/graph?limit=400",
     );
   });
 });

--- a/web/src/test/VaultGraph.test.tsx
+++ b/web/src/test/VaultGraph.test.tsx
@@ -1,0 +1,170 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { App as AntApp, ConfigProvider } from "antd";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import VaultGraph from "@/pages/vault/VaultGraph";
+import NetworkGraph from "@/components/NetworkGraph";
+import { vaultGraphQueryKey } from "@/components/networkGraphQueryKey";
+
+const httpMocks = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock("@/api", () => ({
+  httpClient: { instance: { get: httpMocks.get } },
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...(actual as object),
+    useParams: () => ({ id: "vault-1" }),
+  };
+});
+
+function renderWithProviders(ui: React.ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <ConfigProvider>
+      <AntApp>
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>{ui}</MemoryRouter>
+        </QueryClientProvider>
+      </AntApp>
+    </ConfigProvider>,
+  );
+}
+
+function graphResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    data: {
+      success: true,
+      data: {
+        nodes: [
+          { id: "a", label: "Alice", is_center: false },
+          { id: "b", label: "Bob", is_center: false },
+        ],
+        edges: [],
+        components: 1,
+        isolated_contacts: 0,
+        external_relationships: 0,
+        truncated: false,
+        ...overrides,
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  httpMocks.get.mockReset();
+});
+
+describe("VaultGraph page", () => {
+  it("reads the whole vault rather than one contact's component", async () => {
+    httpMocks.get.mockResolvedValue(graphResponse());
+
+    renderWithProviders(<VaultGraph />);
+
+    await waitFor(() => expect(httpMocks.get).toHaveBeenCalled());
+    expect(httpMocks.get).toHaveBeenCalledWith(
+      "/vaults/vault-1/relationships/graph",
+    );
+    expect(await screen.findByText("2 contacts drawn")).toBeInTheDocument();
+  });
+
+  it("accounts for the contacts and relationships it left out", async () => {
+    httpMocks.get.mockResolvedValue(
+      graphResponse({
+        components: 3,
+        isolated_contacts: 7,
+        external_relationships: 2,
+        truncated: true,
+      }),
+    );
+
+    renderWithProviders(<VaultGraph />);
+
+    expect(await screen.findByText("3 separate clusters")).toBeInTheDocument();
+    expect(
+      screen.getByText("7 not shown, with no relationship inside this vault"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("2 relationships lead outside this vault"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Too large to draw in full; the smallest clusters were left out",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("stays quiet about exclusions that did not happen", async () => {
+    httpMocks.get.mockResolvedValue(graphResponse());
+
+    renderWithProviders(<VaultGraph />);
+
+    await screen.findByText("2 contacts drawn");
+    expect(screen.queryByText(/not shown/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/lead outside/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Too large/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/separate clusters/)).not.toBeInTheDocument();
+  });
+
+  // The page and the canvas are two components reading the same thing; keying
+  // them identically is what keeps that to a single request.
+  it("shares one request with the canvas it renders", async () => {
+    httpMocks.get.mockResolvedValue(graphResponse());
+
+    renderWithProviders(
+      <>
+        <VaultGraph />
+        <NetworkGraph vaultId="vault-1" />
+      </>,
+    );
+
+    await screen.findByText("2 contacts drawn");
+    await waitFor(() => expect(httpMocks.get).toHaveBeenCalledTimes(1));
+    expect(vaultGraphQueryKey("vault-1")).toEqual(["vaults", "vault-1", "graph"]);
+  });
+});
+
+describe("NetworkGraph in vault mode", () => {
+  it("calls the vault endpoint and shows the vault-specific empty state", async () => {
+    httpMocks.get.mockResolvedValue({
+      data: { success: true, data: { nodes: [], edges: [] } },
+    });
+
+    renderWithProviders(
+      <NetworkGraph
+        vaultId="vault-1"
+        emptyDescription="Nothing related in here"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(httpMocks.get).toHaveBeenCalledWith(
+        "/vaults/vault-1/relationships/graph",
+      ),
+    );
+    expect(
+      await screen.findByText("Nothing related in here"),
+    ).toBeInTheDocument();
+  });
+
+  it("still calls the per-contact endpoint when given a contact", async () => {
+    httpMocks.get.mockResolvedValue({
+      data: { success: true, data: { nodes: [], edges: [] } },
+    });
+
+    renderWithProviders(
+      <NetworkGraph vaultId="vault-1" contactId="contact-9" />,
+    );
+
+    await waitFor(() =>
+      expect(httpMocks.get).toHaveBeenCalledWith(
+        "/vaults/vault-1/contacts/contact-9/relationships/graph",
+      ),
+    );
+  });
+});

--- a/web/src/test/VaultGraph.test.tsx
+++ b/web/src/test/VaultGraph.test.tsx
@@ -73,7 +73,7 @@ describe("VaultGraph page", () => {
 
     await waitFor(() => expect(httpMocks.get).toHaveBeenCalled());
     expect(httpMocks.get).toHaveBeenCalledWith(
-      "/vaults/vault-1/relationships/graph?limit=400",
+      "/vaults/vault-1/relationships/graph?limit=1000",
     );
     expect(await screen.findByText("2 contacts drawn")).toBeInTheDocument();
   });
@@ -142,17 +142,17 @@ describe("VaultGraph page", () => {
     renderWithProviders(
       <>
         <VaultGraph />
-        <NetworkGraph vaultId="vault-1" limit={400} />
+        <NetworkGraph vaultId="vault-1" limit={1000} />
       </>,
     );
 
     await screen.findByText("2 contacts drawn");
     await waitFor(() => expect(httpMocks.get).toHaveBeenCalledTimes(1));
-    expect(vaultGraphQueryKey("vault-1", 400)).toEqual([
+    expect(vaultGraphQueryKey("vault-1", 1000)).toEqual([
       "vaults",
       "vault-1",
       "graph",
-      400,
+      1000,
       "",
     ]);
   });
@@ -235,7 +235,7 @@ describe("VaultGraph filtering", () => {
 
     await waitFor(() =>
       expect(httpMocks.get).toHaveBeenCalledWith(
-        "/vaults/vault-1/relationships/graph?limit=400&label=3",
+        "/vaults/vault-1/relationships/graph?limit=1000&label=3",
       ),
     );
   });


### PR DESCRIPTION
Closes #250

bonds can draw one contact's relationship graph — an ego graph, centred on a
person, reached from that person's page. There is no way to see the vault
itself: which families exist in it, which people stand alone, whether the vault
is one network or five unconnected ones. This adds that.

### Server

`GET /vaults/:vault_id/relationships/graph` returns the whole vault: every
contact related to another contact in the same vault, with the same
reciprocal-row collapsing and family inference `GetContactGraph` already does,
and no centre node. It sits behind
`VaultPermissionMiddleware(..., PermissionViewer)`, so read access to the vault
is read access to its shape.

Three things are left out on purpose, and every one of them is counted in the
response rather than dropped in silence — the page states what is missing
instead of quietly showing less than the whole truth:

| field | meaning |
| --- | --- |
| `isolated_contacts` | contacts with no relationship to another contact in the same vault; not drawn |
| `external_relationships` | relationships from a contact in this vault to a *readable* contact outside it; not drawn |
| `components` | how many separate clusters were drawn |
| `truncated` | whole components were dropped to stay within the node limit |

`external_relationships` counts only far ends the caller could otherwise read,
so the count never advertises the existence of a vault they have no access to.

Truncation drops **whole components, largest first**, so the cap never cuts a
family in half. The largest component is kept even when it exceeds the limit on
its own — an oversized drawing the caller is told about beats an empty one.

`limit` is a query parameter, defaulting to 400.

### Filtering

The endpoint also takes facet filters: `gender`, `pronoun`, `religion`,
`company`, `label`, `group`. Each may be repeated (`?label=1&label=2`) or
comma-separated (`?label=1,2`). Within one facet the values are OR-ed; across
facets they are AND-ed — so ticking a second box in one list widens the result
and ticking one in another list narrows it, which is what a reader ticking
boxes expects either way.

The response carries the facet options too, so the page needs one request
rather than two. Two rules make that behave:

- **Options are computed before the filter, over the drawable contacts.**
  Computing them after would make every selection narrow the list it was chosen
  from, and a reader who picked one value could never see the others to pick
  again.
- **A match whose every relation was filtered away is not drawn.** It has
  nothing to show on a relationship graph, and a loose dot is the same noise
  isolated contacts are already excluded to avoid. It is counted alongside the
  contacts the filter rejected outright, under `filtered_out`, because to the
  reader they are one thing: people the filter took off the canvas.

Facets no contact in the vault carries are omitted from the response entirely,
so the page renders a control only where there is something to pick. On the
vault this was built against nobody has a gender, pronoun, religion or company
set, so only the label and group controls appear — and a gender control appears
by itself the moment that changes. That felt better than shipping six selects,
five of which can only ever match nothing.

The lookup tables are read by the ids the vault's contacts actually reference
rather than by account, so a facet can never surface a value belonging to an
account the caller has nothing to do with.

### Web

`NetworkGraph` gained a vault mode rather than a fork: `contactId` is now
optional, so the vault page reuses the existing d3 renderer instead of
duplicating it. Kinship path highlighting still works, because it keys off the
two *selected* nodes rather than a centre.

The new `/vaults/:id/graph` page shares a query key with the canvas it renders,
so one request serves both (there is a test asserting exactly that).

The page carries a node-limit selector (400 / 1000 / 2500 / 5000). This is not
decoration. The first vault I ran it against has 7,722 contacts, 1,373 of them
with an in-vault relationship, in 86 clusters — and its largest cluster alone is
602 people (measured 2026-08-25). So the 400 default could not draw even the
largest cluster on its own, and honestly reported the rest as truncated. Being honest about showing a fraction is not the same as showing
it, and how legible a crowded layout is remains the reader's call, not the
server's.

Strings are translated across all seven locales the project ships.

#### Tests

- 15 Go tests across `internal/services/relationship_vault_graph_test.go` and
  `relationship_vault_graph_facet_test.go` — all pass
- 14 React tests in `web/src/test/VaultGraph.test.tsx` — all pass

`go build ./...` is clean and `go test ./...` passes across all 17 packages
(after `make swagger` — see the note below).

One thing to be straight about: `vitest run` does **not** come back green on
my machine — but it does not on unmodified `main` either. I measured both:
22 test files fail identically on `main` and on this branch, with no file
failing on one and not the other. They look environmental rather than real
(`localStorage is not available because --localstorage-file was not provided`,
plus a `passport.pdf` text assertion). I have left them alone rather than fix
unrelated things inside a feature PR. If they are green in your CI and not
here, that is worth knowing before reading anything into the numbers above.

### Diffstat

```
server/internal/dto/relationship.go                |  45 +++
server/internal/handlers/relationships.go          |  59 ++++
server/internal/handlers/routes.go                 |   3 +
server/internal/services/relationship_graph.go     | 252 ++++++++++++++++
.../internal/services/relationship_graph_facets.go | 318 +++++++++++++++++++++
.../relationship_vault_graph_facet_test.go         | 314 ++++++++++++++++++++
.../services/relationship_vault_graph_test.go      | 227 +++++++++++++++
server/internal/testutil/testutil.go               |  65 +++++
web/src/App.tsx                                    |   2 +
web/src/components/Layout.tsx                      |   2 +
web/src/components/NetworkGraph.tsx                |  40 ++-
web/src/components/networkGraphQueryKey.ts         |  64 +++++
web/src/locales/de.json                            |  24 ++
web/src/locales/en.json                            |  24 ++
web/src/locales/es.json                            |  24 ++
web/src/locales/fr.json                            |  24 ++
web/src/locales/pt-BR.json                         |  24 ++
web/src/locales/pt-PT.json                         |  24 ++
web/src/locales/zh.json                            |  24 ++
web/src/pages/vault/VaultGraph.tsx                 | 203 +++++++++++++
web/src/test/VaultGraph.test.tsx                   | 283 ++++++++++++++++++
21 files changed, 2038 insertions(+), 7 deletions(-)
```

### Notes for review

- Running in production at `prm.akn.me.uk` on `0.22.2` plus these commits.
- Five commits: the vault graph, the reader-settable node limit, the facet
  filters, the PostgreSQL test path, and the 1000-node default. Squash if you
  prefer one commit per PR.
- No migration. The endpoint reads existing tables only.
- `server/docs` is generated and gitignored, so `make swagger` has to run before
  `go build ./...` or `internal/handlers/routes.go` cannot resolve
  `github.com/naiba/bonds/docs`. The new handler carries a full swagger block.
- Why draft: the node-limit default (400), the ladder of options, and which
  attributes deserve to be facets are judgement calls I would rather you set
  than me. Everything else is ready.


---

#### Review follow-up (#250)

- **Default raised 400 → 1000.** Measured against the source vault, server
  time is flat across the ladder (400: 0.82s, 1000: 0.85s, 2500: 0.85s,
  5000: 0.86s) — the cost is the one query that walks the vault, not the size
  of the answer, so the cap is a legibility limit for the force layout rather
  than a database one. 400 could not draw that vault's largest cluster (602
  people) at all. Full numbers in #250.
- **Both databases now tested.** `testutil` gained an env-gated PostgreSQL
  path (`BONDS_TEST_POSTGRES_DSN`); unset, nothing changes. 15/15 vault-graph
  tests pass on SQLite and on PostgreSQL 16.
- **Screenshot** in #250, taken against a synthetic vault so no personal data
  appears.

Pre-existing issue found while testing on PostgreSQL, unrelated to this PR
(no vCard or date code is touched here): `TestExportContactOrgAnniversaryAndTypes`
fails on PostgreSQL with `expected ANNIVERSARY 2015-06-20, got ""` and passes
on SQLite.
