### PR TITLE
fix(addresses): stop address edits from erasing their own coordinates

### DIFF
--- a/server/internal/services/address.go
+++ b/server/internal/services/address.go
@@ -111,7 +111,12 @@ func (s *AddressService) Create(contactID, vaultID string, req dto.CreateAddress
 		return nil, err
 	}
 
-	s.tryGeocode(&address)
+	// Coordinates the caller already knows are kept as given — spending a
+	// provider request to second-guess them would make POST and PUT disagree
+	// about whose coordinates win.
+	if address.Latitude == nil || address.Longitude == nil {
+		s.tryGeocode(&address)
+	}
 
 	if s.feedRecorder != nil {
 		entityType := "Address"
@@ -154,8 +159,22 @@ func (s *AddressService) Update(id uint, contactID, vaultID string, req dto.Upda
 	address.Country = strPtrOrNil(req.Country)
 	address.AddressTypeID = req.AddressTypeID
 
-	coordinatesGiven := req.Latitude != nil && req.Longitude != nil
-	movedElsewhere := geocodeQuery(&address) != previousQuery
+	// A cosmetic edit is not a move: trailing whitespace or a change of case
+	// would be asked of the geocoder as the same question, so it must not cost
+	// the stored coordinates (nor a provider request to recompute them).
+	movedElsewhere := !sameGeocodeQuery(geocodeQuery(&address), previousQuery)
+
+	// Coordinates in the request only count as caller-supplied when they say
+	// something the server did not already say. PUT is full-replace, so a
+	// read-modify-write client echoes the whole object back — including the
+	// coordinates it was handed. If the address text moved but the coordinates
+	// are the old pair verbatim, that is a stale echo, not an instruction to
+	// pin a Vienna address at London forever.
+	echoedCoordinates := req.Latitude != nil && req.Longitude != nil &&
+		previousLatitude != nil && previousLongitude != nil &&
+		*req.Latitude == *previousLatitude && *req.Longitude == *previousLongitude
+	coordinatesGiven := req.Latitude != nil && req.Longitude != nil &&
+		!(movedElsewhere && echoedCoordinates)
 	switch {
 	case coordinatesGiven:
 		address.Latitude = req.Latitude
@@ -186,10 +205,12 @@ func (s *AddressService) Update(id uint, contactID, vaultID string, req dto.Upda
 		return nil, err
 	}
 
-	// Only re-geocode when the address actually moved; re-running it on every
-	// save would spend a provider request, and a rate-limit slot, to arrive back
-	// at the coordinates already stored.
-	if !coordinatesGiven && movedElsewhere {
+	// Re-geocode when the address actually moved — and also when it has no
+	// coordinates at all, because "arrive back at the coordinates already
+	// stored" is no reason to skip when nothing is stored: an address created
+	// while the provider was down would otherwise never get a pin without the
+	// user mangling its text and changing it back.
+	if !coordinatesGiven && (movedElsewhere || address.Latitude == nil || address.Longitude == nil) {
 		s.tryGeocode(&address)
 	}
 
@@ -226,6 +247,15 @@ func geocodeQuery(address *models.Address) string {
 	return strings.Join(parts, ", ")
 }
 
+// sameGeocodeQuery reports whether two geocoding queries would ask the
+// provider the same question: case and whitespace do not change the answer,
+// so they do not count as a move. Whitespace is removed entirely rather than
+// collapsed, because a trimmed field otherwise leaves a stranded separator
+// ("London ," versus "London,") that a word-level comparison still sees.
+func sameGeocodeQuery(a, b string) bool {
+	return strings.EqualFold(strings.Join(strings.Fields(a), ""), strings.Join(strings.Fields(b), ""))
+}
+
 func (s *AddressService) tryGeocode(address *models.Address) {
 	if s.geocoder == nil {
 		return
@@ -245,6 +275,20 @@ func (s *AddressService) tryGeocode(address *models.Address) {
 		return
 	}
 	if result == nil {
+		return
+	}
+	// The provider can take seconds to answer, and this runs after the edit's
+	// transaction committed — the row may already describe somewhere else. A
+	// late answer for the old text must not overwrite the newer edit's
+	// coordinates, so re-read and only store if the row still asks the same
+	// question that was geocoded. (A concurrent edit landing in the microseconds
+	// between this check and the write can still lose, but that window is the
+	// provider round-trip no longer.)
+	var current models.Address
+	if err := s.db.First(&current, address.ID).Error; err != nil {
+		return
+	}
+	if !sameGeocodeQuery(geocodeQuery(&current), query) {
 		return
 	}
 	address.Latitude = &result.Latitude

--- a/server/internal/services/address.go
+++ b/server/internal/services/address.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"errors"
+	"log"
+	"strings"
 	"time"
 
 	"github.com/naiba/bonds/internal/dto"
@@ -135,6 +137,13 @@ func (s *AddressService) Update(id uint, contactID, vaultID string, req dto.Upda
 		return nil, ErrAddressNotFound
 	}
 
+	// Remember where the address was before it is overwritten, so an edit that
+	// does not move it keeps its coordinates. The address form does not send
+	// latitude or longitude, so assigning them straight from the request would
+	// erase the geocode on every save and nothing would ever recompute it.
+	previousQuery := geocodeQuery(&address)
+	previousLatitude, previousLongitude := address.Latitude, address.Longitude
+
 	address.Line1 = strPtrOrNil(req.Line1)
 	address.Line2 = strPtrOrNil(req.Line2)
 	address.City = strPtrOrNil(req.City)
@@ -142,8 +151,24 @@ func (s *AddressService) Update(id uint, contactID, vaultID string, req dto.Upda
 	address.PostalCode = strPtrOrNil(req.PostalCode)
 	address.Country = strPtrOrNil(req.Country)
 	address.AddressTypeID = req.AddressTypeID
-	address.Latitude = req.Latitude
-	address.Longitude = req.Longitude
+
+	coordinatesGiven := req.Latitude != nil && req.Longitude != nil
+	movedElsewhere := geocodeQuery(&address) != previousQuery
+	switch {
+	case coordinatesGiven:
+		address.Latitude = req.Latitude
+		address.Longitude = req.Longitude
+	case movedElsewhere:
+		// The address now describes somewhere else, so the old coordinates are
+		// simply wrong. Drop them before re-geocoding: keeping them until a
+		// replacement arrives would leave the address pinned to its previous
+		// location whenever the provider errors or finds nothing, which is a
+		// worse answer than having no pin at all.
+		address.Latitude, address.Longitude = nil, nil
+	default:
+		address.Latitude = previousLatitude
+		address.Longitude = previousLongitude
+	}
 
 	isPast := req.IsPastAddress || req.DateTo != nil
 	err := s.db.Transaction(func(tx *gorm.DB) error {
@@ -157,6 +182,13 @@ func (s *AddressService) Update(id uint, contactID, vaultID string, req dto.Upda
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// Only re-geocode when the address actually moved; re-running it on every
+	// save would spend a provider request, and a rate-limit slot, to arrive back
+	// at the coordinates already stored.
+	if !coordinatesGiven && movedElsewhere {
+		s.tryGeocode(&address)
 	}
 
 	resp := toAddressResponse(&address, isPast, req.DateFrom, req.DateTo)
@@ -179,33 +211,43 @@ func (s *AddressService) Delete(id uint, contactID, vaultID string) error {
 	})
 }
 
-func (s *AddressService) tryGeocode(address *models.Address) {
-	if s.geocoder == nil {
-		return
-	}
+// geocodeQuery renders the address as the single line a geocoder is asked
+// about. Line 2 is left out deliberately: flat and building numbers are noise
+// to a geocoder and routinely cost it the match.
+func geocodeQuery(address *models.Address) string {
 	parts := []string{}
 	for _, p := range []*string{address.Line1, address.City, address.Province, address.PostalCode, address.Country} {
 		if p != nil && *p != "" {
 			parts = append(parts, *p)
 		}
 	}
-	if len(parts) == 0 {
+	return strings.Join(parts, ", ")
+}
+
+func (s *AddressService) tryGeocode(address *models.Address) {
+	if s.geocoder == nil {
 		return
 	}
-	query := ""
-	for i, p := range parts {
-		if i > 0 {
-			query += ", "
-		}
-		query += p
+	query := geocodeQuery(address)
+	if query == "" {
+		return
 	}
 	result, err := s.geocoder.Geocode(query)
-	if err != nil || result == nil {
+	if err != nil {
+		// Worth a line in the log: a misconfigured provider or a blocked IP is
+		// otherwise completely invisible, and the only symptom is addresses
+		// quietly never getting coordinates.
+		log.Printf("geocoding %q failed: %v", query, err)
+		return
+	}
+	if result == nil {
 		return
 	}
 	address.Latitude = &result.Latitude
 	address.Longitude = &result.Longitude
-	s.db.Model(address).Select("latitude", "longitude").Updates(address)
+	if err := s.db.Model(address).Select("latitude", "longitude").Updates(address).Error; err != nil {
+		log.Printf("storing geocode for address %d failed: %v", address.ID, err)
+	}
 }
 
 func toAddressResponse(a *models.Address, isPastAddress bool, dateFrom, dateTo *time.Time) dto.AddressResponse {

--- a/server/internal/services/address.go
+++ b/server/internal/services/address.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"errors"
+	"fmt"
 	"log"
+	"net/url"
 	"strings"
 	"time"
 
@@ -236,8 +238,10 @@ func (s *AddressService) tryGeocode(address *models.Address) {
 	if err != nil {
 		// Worth a line in the log: a misconfigured provider or a blocked IP is
 		// otherwise completely invisible, and the only symptom is addresses
-		// quietly never getting coordinates.
-		log.Printf("geocoding %q failed: %v", query, err)
+		// quietly never getting coordinates. The query itself stays out of the
+		// log, though — in exact mode it is a contact's complete home address,
+		// and the address ID identifies the row just as well.
+		log.Printf("geocoding address %d via %T failed: %v", address.ID, s.geocoder, redactGeocodeError(err))
 		return
 	}
 	if result == nil {
@@ -248,6 +252,18 @@ func (s *AddressService) tryGeocode(address *models.Address) {
 	if err := s.db.Model(address).Select("latitude", "longitude").Updates(address).Error; err != nil {
 		log.Printf("storing geocode for address %d failed: %v", address.ID, err)
 	}
+}
+
+// redactGeocodeError strips the request URL from a geocoding failure before
+// it reaches the log. A transport error carries the full URL it was for, and
+// that URL embeds the geocoding query — the same address the log line above
+// deliberately leaves out.
+func redactGeocodeError(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return fmt.Errorf("%s request failed: %w", urlErr.Op, urlErr.Err)
+	}
+	return err
 }
 
 func toAddressResponse(a *models.Address, isPastAddress bool, dateFrom, dateTo *time.Time) dto.AddressResponse {

--- a/server/internal/services/address.go
+++ b/server/internal/services/address.go
@@ -278,24 +278,25 @@ func (s *AddressService) tryGeocode(address *models.Address) {
 		return
 	}
 	// The provider can take seconds to answer, and this runs after the edit's
-	// transaction committed — the row may already describe somewhere else. A
-	// late answer for the old text must not overwrite the newer edit's
-	// coordinates, so re-read and only store if the row still asks the same
-	// question that was geocoded. (A concurrent edit landing in the microseconds
-	// between this check and the write can still lose, but that window is the
-	// provider round-trip no longer.)
-	var current models.Address
-	if err := s.db.First(&current, address.ID).Error; err != nil {
+	// transaction committed — the row may already have been edited again. Make
+	// the address version we geocoded part of the UPDATE itself so a newer edit
+	// cannot land between a separate check and this write.
+	stored := s.db.Model(&models.Address{}).
+		Where("id = ? AND updated_at = ?", address.ID, address.UpdatedAt).
+		Select("latitude", "longitude").
+		Updates(map[string]any{
+			"latitude":  result.Latitude,
+			"longitude": result.Longitude,
+		})
+	if stored.Error != nil {
+		log.Printf("storing geocode for address %d failed: %v", address.ID, stored.Error)
 		return
 	}
-	if !sameGeocodeQuery(geocodeQuery(&current), query) {
+	if stored.RowsAffected == 0 {
 		return
 	}
 	address.Latitude = &result.Latitude
 	address.Longitude = &result.Longitude
-	if err := s.db.Model(address).Select("latitude", "longitude").Updates(address).Error; err != nil {
-		log.Printf("storing geocode for address %d failed: %v", address.ID, err)
-	}
 }
 
 // redactGeocodeError strips the request URL from a geocoding failure before

--- a/server/internal/services/address_geocode_test.go
+++ b/server/internal/services/address_geocode_test.go
@@ -1,7 +1,13 @@
 package services
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/naiba/bonds/internal/dto"
@@ -180,5 +186,51 @@ func TestUpdateAddressDropsCoordinatesWhenProviderFindsNothing(t *testing.T) {
 	}
 	if latitude, _ := storedCoordinates(t, svc, created.ID); latitude != nil {
 		t.Fatalf("expected no coordinates for an unresolvable address, got %v", *latitude)
+	}
+}
+
+// urlErrorGeocoder fails the way a real provider does over HTTP: with a
+// transport error that carries the full request URL, query string and all.
+type urlErrorGeocoder struct{}
+
+func (g *urlErrorGeocoder) Geocode(address string) (*GeocodingResult, error) {
+	return nil, &url.Error{
+		Op:  "Get",
+		URL: "https://nominatim.openstreetmap.org/search?q=" + url.QueryEscape(address),
+		Err: errors.New("connection refused"),
+	}
+}
+
+func TestGeocodeFailureLogLeavesTheAddressOut(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+	svc.SetGeocoder(&urlErrorGeocoder{})
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	created, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	logged := buf.String()
+	if logged == "" {
+		t.Fatal("expected the geocoding failure to be logged")
+	}
+	// Neither the query nor the request URL may appear: in exact mode both are
+	// a contact's complete home address.
+	for _, fragment := range []string{"Downing", "London", "United Kingdom", "q="} {
+		if strings.Contains(logged, fragment) {
+			t.Fatalf("log line leaks the address (%q): %s", fragment, logged)
+		}
+	}
+	if !strings.Contains(logged, fmt.Sprintf("address %d", created.ID)) {
+		t.Fatalf("log line should identify the address by ID: %s", logged)
+	}
+	if !strings.Contains(logged, "connection refused") {
+		t.Fatalf("log line should keep the underlying cause: %s", logged)
 	}
 }

--- a/server/internal/services/address_geocode_test.go
+++ b/server/internal/services/address_geocode_test.go
@@ -22,10 +22,16 @@ type stubGeocoder struct {
 	longitude float64
 	fail      bool
 	noMatch   bool
+	// onGeocode runs while the provider is "on the wire", so tests can stage
+	// what happens between an edit's commit and the geocode answer landing.
+	onGeocode func()
 }
 
 func (g *stubGeocoder) Geocode(address string) (*GeocodingResult, error) {
 	g.queries = append(g.queries, address)
+	if g.onGeocode != nil {
+		g.onGeocode()
+	}
 	if g.fail {
 		return nil, errors.New("provider unavailable")
 	}
@@ -196,7 +202,7 @@ type urlErrorGeocoder struct{}
 func (g *urlErrorGeocoder) Geocode(address string) (*GeocodingResult, error) {
 	return nil, &url.Error{
 		Op:  "Get",
-		URL: "https://nominatim.openstreetmap.org/search?q=" + url.QueryEscape(address),
+		URL: "https://us1.locationiq.com/v1/search?key=super-secret-api-key&q=" + url.QueryEscape(address),
 		Err: errors.New("connection refused"),
 	}
 }
@@ -222,7 +228,8 @@ func TestGeocodeFailureLogLeavesTheAddressOut(t *testing.T) {
 	}
 	// Neither the query nor the request URL may appear: in exact mode both are
 	// a contact's complete home address.
-	for _, fragment := range []string{"Downing", "London", "United Kingdom", "q="} {
+	// The API key rides in the same URL, so it must go down with it.
+	for _, fragment := range []string{"Downing", "London", "United Kingdom", "q=", "super-secret-api-key"} {
 		if strings.Contains(logged, fragment) {
 			t.Fatalf("log line leaks the address (%q): %s", fragment, logged)
 		}
@@ -232,5 +239,176 @@ func TestGeocodeFailureLogLeavesTheAddressOut(t *testing.T) {
 	}
 	if !strings.Contains(logged, "connection refused") {
 		t.Fatalf("log line should keep the underlying cause: %s", logged)
+	}
+}
+
+// PUT is full-replace, so a read-modify-write API client echoes the whole
+// object back — coordinates included. Echoed coordinates on a moved address
+// are a stale copy of what the server said, not an instruction to keep the
+// old pin, and treating them as authoritative would pin the moved address to
+// its old location permanently (every subsequent echo re-supplies them).
+func TestUpdateAddressTreatsEchoedCoordinatesAsStale(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+	geocoder := &stubGeocoder{latitude: 51.5072, longitude: -0.1276}
+	svc.SetGeocoder(geocoder)
+
+	created, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// The provider now answers for the new city.
+	geocoder.latitude, geocoder.longitude = 48.2082, 16.3738
+	london := 51.5072
+	londonLongitude := -0.1276
+	if _, err := svc.Update(created.ID, contactID, vaultID, dto.UpdateAddressRequest{
+		Line1: "10 Downing Street", City: "Vienna", Country: "Austria",
+		Latitude: &london, Longitude: &londonLongitude,
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	latitude, longitude := storedCoordinates(t, svc, created.ID)
+	if latitude == nil || *latitude != 48.2082 || longitude == nil || *longitude != 16.3738 {
+		t.Fatalf("a moved address with echoed coordinates must be re-geocoded, got %v, %v", latitude, longitude)
+	}
+
+	// Coordinates that DIFFER from what the server handed out are a deliberate
+	// override and still win.
+	custom, customLongitude := 40.0, -70.0
+	if _, err := svc.Update(created.ID, contactID, vaultID, dto.UpdateAddressRequest{
+		Line1: "10 Downing Street", City: "Berlin", Country: "Germany",
+		Latitude: &custom, Longitude: &customLongitude,
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	latitude, longitude = storedCoordinates(t, svc, created.ID)
+	if latitude == nil || *latitude != 40.0 {
+		t.Fatalf("caller-chosen coordinates must win, got %v", latitude)
+	}
+}
+
+// Trailing whitespace or a change of case would be asked of the geocoder as
+// the same question — it is not a move, and must not cost the pin (nor spend
+// a provider request), even when the provider is down.
+func TestUpdateAddressKeepsCoordinatesOnCosmeticEdit(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+	geocoder := &stubGeocoder{latitude: 51.5072, longitude: -0.1276}
+	svc.SetGeocoder(geocoder)
+
+	created, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1: "10 Downing Street", City: "London ", Country: "UNITED KINGDOM",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// The provider goes down; the cosmetic edit must not need it.
+	geocoder.fail = true
+	if _, err := svc.Update(created.ID, contactID, vaultID, dto.UpdateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	latitude, longitude := storedCoordinates(t, svc, created.ID)
+	if latitude == nil || longitude == nil {
+		t.Fatal("a cosmetic edit erased the coordinates")
+	}
+	if len(geocoder.queries) != 1 {
+		t.Fatalf("a cosmetic edit must not spend a provider request, got %d calls", len(geocoder.queries))
+	}
+}
+
+// An address created while the provider was down has no pin, and "the stored
+// coordinates are already right" is no reason to skip re-geocoding when
+// nothing is stored: a plain save must be able to heal it.
+func TestUpdateAddressRetriesGeocodeWhenPinMissing(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+	geocoder := &stubGeocoder{latitude: 51.5072, longitude: -0.1276, fail: true}
+	svc.SetGeocoder(geocoder)
+
+	created, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if latitude, _ := storedCoordinates(t, svc, created.ID); latitude != nil {
+		t.Fatal("precondition: the failed create should have stored no coordinates")
+	}
+
+	geocoder.fail = false
+	if _, err := svc.Update(created.ID, contactID, vaultID, dto.UpdateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	latitude, longitude := storedCoordinates(t, svc, created.ID)
+	if latitude == nil || *latitude != 51.5072 || longitude == nil {
+		t.Fatalf("an unchanged save should have healed the missing pin, got %v, %v", latitude, longitude)
+	}
+}
+
+// The geocode answer arrives after the edit's transaction committed, and the
+// row may have been edited again while the provider was thinking. The late
+// answer is for a question the row no longer asks, and must not be stored.
+func TestLateGeocodeAnswerDoesNotClobberANewerEdit(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+	geocoder := &stubGeocoder{latitude: 51.5072, longitude: -0.1276}
+	svc.SetGeocoder(geocoder)
+
+	created, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// While Vienna's geocode is "on the wire", the address moves on to Berlin.
+	geocoder.latitude, geocoder.longitude = 48.2082, 16.3738
+	geocoder.onGeocode = func() {
+		geocoder.onGeocode = nil
+		if err := svc.db.Model(&models.Address{}).Where("id = ?", created.ID).
+			Updates(map[string]any{"city": "Berlin", "country": "Germany", "latitude": 52.52, "longitude": 13.405}).Error; err != nil {
+			t.Fatalf("staging the concurrent edit: %v", err)
+		}
+	}
+	if _, err := svc.Update(created.ID, contactID, vaultID, dto.UpdateAddressRequest{
+		Line1: "10 Downing Street", City: "Vienna", Country: "Austria",
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	latitude, longitude := storedCoordinates(t, svc, created.ID)
+	if latitude == nil || *latitude != 52.52 || longitude == nil || *longitude != 13.405 {
+		t.Fatalf("Vienna's late answer clobbered Berlin's coordinates: %v, %v", latitude, longitude)
+	}
+}
+
+// POST with coordinates the caller already knows must store them as given —
+// spending a provider request to second-guess them would make Create and
+// Update disagree about whose coordinates win.
+func TestCreateAddressKeepsCallerCoordinates(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+	geocoder := &stubGeocoder{latitude: 51.5072, longitude: -0.1276}
+	svc.SetGeocoder(geocoder)
+
+	latitude, longitude := 48.8566, 2.3522
+	created, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1: "48 Rue de Rivoli", City: "Paris", Country: "France",
+		Latitude: &latitude, Longitude: &longitude,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	stored, storedLongitude := storedCoordinates(t, svc, created.ID)
+	if stored == nil || *stored != 48.8566 || storedLongitude == nil || *storedLongitude != 2.3522 {
+		t.Fatalf("caller coordinates must be stored as given, got %v, %v", stored, storedLongitude)
+	}
+	if len(geocoder.queries) != 0 {
+		t.Fatalf("no provider request should be spent on known coordinates, got %d", len(geocoder.queries))
 	}
 }

--- a/server/internal/services/address_geocode_test.go
+++ b/server/internal/services/address_geocode_test.go
@@ -1,0 +1,184 @@
+package services
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/naiba/bonds/internal/dto"
+	"github.com/naiba/bonds/internal/models"
+)
+
+// stubGeocoder answers with fixed coordinates, and can be made to fail or to
+// find nothing, which is where the interesting behaviour is.
+type stubGeocoder struct {
+	queries   []string
+	latitude  float64
+	longitude float64
+	fail      bool
+	noMatch   bool
+}
+
+func (g *stubGeocoder) Geocode(address string) (*GeocodingResult, error) {
+	g.queries = append(g.queries, address)
+	if g.fail {
+		return nil, errors.New("provider unavailable")
+	}
+	if g.noMatch {
+		return nil, nil
+	}
+	return &GeocodingResult{Latitude: g.latitude, Longitude: g.longitude}, nil
+}
+
+func storedCoordinates(t *testing.T, svc *AddressService, id uint) (*float64, *float64) {
+	t.Helper()
+	var address models.Address
+	if err := svc.db.First(&address, id).Error; err != nil {
+		t.Fatalf("reloading address: %v", err)
+	}
+	return address.Latitude, address.Longitude
+}
+
+func TestUpdateAddressKeepsCoordinatesWhenNotMoved(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+	geocoder := &stubGeocoder{latitude: 51.5072, longitude: -0.1276}
+	svc.SetGeocoder(geocoder)
+
+	created, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if len(geocoder.queries) != 1 {
+		t.Fatalf("expected the new address to be geocoded once, got %d calls", len(geocoder.queries))
+	}
+
+	// The address form does not send coordinates. Before this was fixed, that
+	// alone wiped them on every save and nothing ever recomputed them.
+	if _, err := svc.Update(created.ID, contactID, vaultID, dto.UpdateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	latitude, longitude := storedCoordinates(t, svc, created.ID)
+	if latitude == nil || longitude == nil {
+		t.Fatal("editing an address must not erase its coordinates")
+	}
+	if *latitude != 51.5072 || *longitude != -0.1276 {
+		t.Fatalf("unexpected coordinates: %v, %v", *latitude, *longitude)
+	}
+	if len(geocoder.queries) != 1 {
+		t.Fatalf("expected no re-geocode for an unchanged address, got %d calls", len(geocoder.queries))
+	}
+}
+
+func TestUpdateAddressRegeocodesWhenMoved(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+	geocoder := &stubGeocoder{latitude: 51.5072, longitude: -0.1276}
+	svc.SetGeocoder(geocoder)
+
+	created, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	geocoder.latitude, geocoder.longitude = 48.2082, 16.3738
+	if _, err := svc.Update(created.ID, contactID, vaultID, dto.UpdateAddressRequest{
+		Line1: "Stephansplatz 1", City: "Vienna", Country: "Austria",
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	latitude, longitude := storedCoordinates(t, svc, created.ID)
+	if latitude == nil || *latitude != 48.2082 || longitude == nil || *longitude != 16.3738 {
+		t.Fatalf("expected the moved address to be re-geocoded, got %v, %v", latitude, longitude)
+	}
+	if len(geocoder.queries) != 2 {
+		t.Fatalf("expected exactly one re-geocode, got %d calls", len(geocoder.queries))
+	}
+	if geocoder.queries[1] != "Stephansplatz 1, Vienna, Austria" {
+		t.Fatalf("unexpected geocoding query: %q", geocoder.queries[1])
+	}
+}
+
+func TestUpdateAddressPrefersCallerSuppliedCoordinates(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+	geocoder := &stubGeocoder{latitude: 51.5072, longitude: -0.1276}
+	svc.SetGeocoder(geocoder)
+
+	created, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	latitude, longitude := 48.2082, 16.3738
+	if _, err := svc.Update(created.ID, contactID, vaultID, dto.UpdateAddressRequest{
+		Line1: "Stephansplatz 1", City: "Vienna", Country: "Austria",
+		Latitude: &latitude, Longitude: &longitude,
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	storedLat, storedLon := storedCoordinates(t, svc, created.ID)
+	if storedLat == nil || *storedLat != 48.2082 || storedLon == nil || *storedLon != 16.3738 {
+		t.Fatalf("expected the supplied coordinates to be kept, got %v, %v", storedLat, storedLon)
+	}
+	if len(geocoder.queries) != 1 {
+		t.Fatalf("expected no extra geocode, got %d calls", len(geocoder.queries))
+	}
+}
+
+func TestUpdateAddressDropsCoordinatesWhenGeocodingFails(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+	geocoder := &stubGeocoder{latitude: 51.5072, longitude: -0.1276}
+	svc.SetGeocoder(geocoder)
+
+	created, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// The address moves and the provider cannot answer. Keeping the previous
+	// coordinates would leave this address pinned to London on a map.
+	geocoder.fail = true
+	if _, err := svc.Update(created.ID, contactID, vaultID, dto.UpdateAddressRequest{
+		Line1: "Stephansplatz 1", City: "Vienna", Country: "Austria",
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	latitude, longitude := storedCoordinates(t, svc, created.ID)
+	if latitude != nil || longitude != nil {
+		t.Fatalf("a moved address must not keep its old coordinates, got %v, %v", latitude, longitude)
+	}
+}
+
+func TestUpdateAddressDropsCoordinatesWhenProviderFindsNothing(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+	geocoder := &stubGeocoder{latitude: 51.5072, longitude: -0.1276}
+	svc.SetGeocoder(geocoder)
+
+	created, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	geocoder.noMatch = true
+	if _, err := svc.Update(created.ID, contactID, vaultID, dto.UpdateAddressRequest{
+		Line1: "Nowhere At All", City: "Nowhereville", Country: "Atlantis",
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if latitude, _ := storedCoordinates(t, svc, created.ID); latitude != nil {
+		t.Fatalf("expected no coordinates for an unresolvable address, got %v", *latitude)
+	}
+}

--- a/server/internal/services/address_geocode_test.go
+++ b/server/internal/services/address_geocode_test.go
@@ -9,9 +9,11 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/naiba/bonds/internal/dto"
 	"github.com/naiba/bonds/internal/models"
+	"gorm.io/gorm"
 )
 
 // stubGeocoder answers with fixed coordinates, and can be made to fail or to
@@ -385,6 +387,62 @@ func TestLateGeocodeAnswerDoesNotClobberANewerEdit(t *testing.T) {
 	latitude, longitude := storedCoordinates(t, svc, created.ID)
 	if latitude == nil || *latitude != 52.52 || longitude == nil || *longitude != 13.405 {
 		t.Fatalf("Vienna's late answer clobbered Berlin's coordinates: %v, %v", latitude, longitude)
+	}
+}
+
+// Even a newer edit that lands after the provider answer has been accepted
+// but immediately before its coordinates are written must win. This stages
+// that edit in GORM's update callback: the optimistic updated_at predicate is
+// already built, then the row version changes before the SQL executes.
+func TestGeocodeCoordinateWriteIsAtomicWithAddressVersion(t *testing.T) {
+	svc, contactID, vaultID := setupAddressTest(t)
+	geocoder := &stubGeocoder{latitude: 51.5072, longitude: -0.1276}
+	svc.SetGeocoder(geocoder)
+
+	created, err := svc.Create(contactID, vaultID, dto.CreateAddressRequest{
+		Line1: "10 Downing Street", City: "London", Country: "United Kingdom",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	const callbackName = "test:edit_before_geocode_coordinate_write"
+	fired := false
+	if err := svc.db.Callback().Update().Before("gorm:update").Register(callbackName, func(tx *gorm.DB) {
+		if fired || len(tx.Statement.Selects) != 2 ||
+			tx.Statement.Selects[0] != "latitude" || tx.Statement.Selects[1] != "longitude" {
+			return
+		}
+		fired = true
+		newerVersion := time.Now().UTC().Add(time.Hour)
+		if err := tx.Session(&gorm.Session{SkipHooks: true}).Exec(
+			"UPDATE addresses SET city = ?, country = ?, latitude = ?, longitude = ?, updated_at = ? WHERE id = ?",
+			"Berlin", "Germany", 52.52, 13.405, newerVersion, created.ID,
+		).Error; err != nil {
+			t.Fatalf("staging edit immediately before coordinate write: %v", err)
+		}
+	}); err != nil {
+		t.Fatalf("registering update callback: %v", err)
+	}
+	defer func() {
+		if err := svc.db.Callback().Update().Remove(callbackName); err != nil {
+			t.Fatalf("removing update callback: %v", err)
+		}
+	}()
+
+	geocoder.latitude, geocoder.longitude = 48.2082, 16.3738
+	if _, err := svc.Update(created.ID, contactID, vaultID, dto.UpdateAddressRequest{
+		Line1: "Stephansplatz 1", City: "Vienna", Country: "Austria",
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if !fired {
+		t.Fatal("the concurrent-edit callback did not intercept the coordinate write")
+	}
+
+	latitude, longitude := storedCoordinates(t, svc, created.ID)
+	if latitude == nil || *latitude != 52.52 || longitude == nil || *longitude != 13.405 {
+		t.Fatalf("Vienna's coordinate write clobbered the newer Berlin edit: %v, %v", latitude, longitude)
 	}
 }
 


### PR DESCRIPTION
Split out of #259 on review.

`AddressService.Update` assigned `Latitude` and `Longitude` straight from the
request, but the address form never sends them — the payload it builds has
`line_1` through `country`, the dates and `is_past_address`, and nothing else.
Every edit through the UI therefore bound them as nil and saved that over the
stored geocode, and nothing recomputed it, because `Update` never called
`tryGeocode`. An address lost its coordinates permanently the first time
anyone corrected a typo in it.

An edit now keeps the coordinates it had, and re-geocodes only when the address
text actually changed — re-running it on every save would spend a provider
request, and a rate-limit slot, to arrive back at the same answer. Coordinates
supplied by the caller still win.

When the address does change, the old coordinates are cleared **before** the
lookup rather than kept as a fallback (review point 3). If the provider errors
or finds nothing, no coordinates is the truthful answer; keeping the previous
ones would leave the address confidently plotted at its old location.

Five tests, including the two failure paths. I confirmed the first fails
against the previous behaviour rather than passing vacuously.
