### PR TITLE
fix(contacts): make the section navigation usable, and sticky work at all

### DIFF
--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -420,6 +420,7 @@ export type { GithubComNaibaBondsInternalDtoUpdateContactReligionRequest as Upda
 export type { GithubComNaibaBondsInternalDtoContactLabelResponse as ContactLabel } from "./generated/data-contracts";
 export type { GithubComNaibaBondsInternalDtoContactTabsResponse as ContactTabsResponse } from "./generated/data-contracts";
 export type { GithubComNaibaBondsInternalDtoContactTabPage as ContactTabPage } from "./generated/data-contracts";
+export type { GithubComNaibaBondsInternalDtoContactTabModule as ContactTabModule } from "./generated/data-contracts";
 export type { GithubComNaibaBondsInternalDtoContactLayoutResponse as ContactLayout } from "./generated/data-contracts";
 export type { GithubComNaibaBondsInternalDtoContactLayoutPage as ContactLayoutPage } from "./generated/data-contracts";
 export type { GithubComNaibaBondsInternalDtoContactLayoutModuleDefinition as ContactLayoutModuleDefinition } from "./generated/data-contracts";

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -334,7 +334,12 @@ export default function Layout() {
           padding: "24px 16px",
           background: token.colorBgLayout,
           minHeight: 280,
-          overflow: "auto",
+          // Deliberately not `overflow: auto`. Any scrollable ancestor becomes
+          // the containing block for position:sticky inside it, so an overflow
+          // here silently stops the contact-section nav (and anything else
+          // sticky) from sticking to the viewport. Wide content scrolls in its
+          // own container instead.
+          minWidth: 0,
         }}
       >
         <div style={{ maxWidth: 1600, margin: "0 auto" }}>

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -338,7 +338,11 @@ export default function Layout() {
           // the containing block for position:sticky inside it, so an overflow
           // here silently stops the contact-section nav (and anything else
           // sticky) from sticking to the viewport. Wide content scrolls in its
-          // own container instead.
+          // own container instead — and `clip` (which, unlike auto/hidden,
+          // creates no scroll container and leaves sticky alone) guarantees
+          // that anything without its own container can only be cut at the
+          // edge, never widen the document and pan the header off-screen.
+          overflowX: "clip",
           minWidth: 0,
         }}
       >

--- a/web/src/pages/contact/ContactDetail.tsx
+++ b/web/src/pages/contact/ContactDetail.tsx
@@ -17,6 +17,7 @@ import {
   timestampToDateInput,
 } from "@/utils/dateOnlyInput";
 import CalendarDatePicker from "@/components/CalendarDatePicker";
+import { sectionNavCards } from "@/pages/contact/sectionNavCards";
 import type { CalendarDatePickerValue } from "@/components/CalendarDatePicker";
 import {
   buildContactFirstMetRequest,
@@ -361,7 +362,10 @@ function ContactSectionLayout({
     [],
   );
 
-  const jumpToSection = (key: string) => {
+  // Marks a section current and makes sure it is mounted, without moving the
+  // page. Kept separate from scrolling so that jumping to a card does not also
+  // start a competing smooth scroll to the top of its section.
+  const openSection = (key: string) => {
     setActiveSectionKey(key);
     setLoadedSectionKeys((current) => {
       if (current.has(key)) return current;
@@ -369,10 +373,33 @@ function ContactSectionLayout({
       next.add(key);
       return next;
     });
+  };
+
+  const jumpToSection = (key: string) => {
+    openSection(key);
     const section = getSectionNodes().find(
       (node) => node.dataset.contactSectionKey === key,
     );
     section?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  // Scrolls to one card within a section. Sections below the fold are not
+  // rendered until they are needed, so the card may not exist yet — hence the
+  // few frames of grace before giving up.
+  const jumpToModule = (sectionKey: string, moduleKey: string) => {
+    openSection(sectionKey);
+    let attempts = 0;
+    const scrollWhenReady = () => {
+      const node = containerRef.current?.querySelector<HTMLElement>(
+        `[data-contact-module-key="${moduleKey}"]`,
+      );
+      if (node) {
+        node.scrollIntoView({ behavior: "smooth", block: "start" });
+        return;
+      }
+      if (attempts++ < 10) requestAnimationFrame(scrollWhenReady);
+    };
+    requestAnimationFrame(scrollWhenReady);
   };
 
   useEffect(() => {
@@ -495,28 +522,73 @@ function ContactSectionLayout({
       <Space orientation="vertical" size={2} style={{ width: "100%" }}>
         {pageEntries.map((entry) => {
           const active = entry.key === currentSectionKey;
+          // Only the section being read is expanded into its cards: showing
+          // every card of every section would be a wall of forty links, and the
+          // point of this nav is to be scannable.
+          //
+          // A lone card that just restates its section's name is dropped —
+          // "Activities > Activities" tells the reader nothing, and repeating
+          // the name puts two identically labelled buttons in one navigation,
+          // which is ambiguous to a screen reader and to anything selecting by
+          // accessible name. Sections whose single card is named differently
+          // ("Summary" holding "Contact summary") still expand: suppressing
+          // every single-card section made the control look broken, because in
+          // a default layout five of the eight sections hold one card.
+          const cards = active ? sectionNavCards(entry.page) : [];
           return (
-            <Button
-              key={entry.key}
-              type="text"
-              block
-              aria-current={active ? "location" : undefined}
-              onClick={() => jumpToSection(entry.key)}
-              style={{
-                height: "auto",
-                minHeight: 34,
-                padding: "7px 10px",
-                textAlign: "left",
-                justifyContent: "flex-start",
-                whiteSpace: "normal",
-                lineHeight: 1.35,
-                color: active ? token.colorPrimary : token.colorTextSecondary,
-                background: active ? token.colorPrimaryBg : undefined,
-                fontWeight: active ? 600 : 400,
-              }}
-            >
-              {entry.page.name ?? entry.page.slug ?? ""}
-            </Button>
+            <div key={entry.key} style={{ width: "100%" }}>
+              <Button
+                type="text"
+                block
+                aria-current={active ? "location" : undefined}
+                onClick={() => jumpToSection(entry.key)}
+                style={{
+                  height: "auto",
+                  minHeight: 34,
+                  padding: "7px 10px",
+                  textAlign: "left",
+                  justifyContent: "flex-start",
+                  whiteSpace: "normal",
+                  lineHeight: 1.35,
+                  color: active ? token.colorPrimary : token.colorTextSecondary,
+                  background: active ? token.colorPrimaryBg : undefined,
+                  fontWeight: active ? 600 : 400,
+                }}
+              >
+                {entry.page.name ?? entry.page.slug ?? ""}
+              </Button>
+              {cards.length > 0 && (
+                <div
+                  style={{
+                    marginLeft: 10,
+                    paddingLeft: 8,
+                    borderLeft: `1px solid ${token.colorSplit}`,
+                  }}
+                >
+                  {cards.map((card) => (
+                    <Button
+                      key={card.id}
+                      type="text"
+                      block
+                      onClick={() => jumpToModule(entry.key, `mod-${card.id}`)}
+                      style={{
+                        height: "auto",
+                        minHeight: 26,
+                        padding: "4px 8px",
+                        textAlign: "left",
+                        justifyContent: "flex-start",
+                        whiteSpace: "normal",
+                        lineHeight: 1.3,
+                        fontSize: 12,
+                        color: token.colorTextTertiary,
+                      }}
+                    >
+                      {card.name ?? card.type ?? ""}
+                    </Button>
+                  ))}
+                </div>
+              )}
+            </div>
           );
         })}
       </Space>
@@ -1407,12 +1479,32 @@ export default function ContactDetail() {
     if (children.length === 0) {
       return null;
     }
-    if (children.length === 1) {
-      return children[0];
+
+    // Each card is wrapped in an anchor carrying the key it was pushed with, so
+    // the section navigation can scroll straight to one card rather than only
+    // to the top of the page it lives on.
+    const anchored = children.map((child, index) => {
+      const key =
+        React.isValidElement(child) && child.key != null
+          ? String(child.key)
+          : `child-${index}`;
+      return (
+        <div
+          key={key}
+          data-contact-module-key={key}
+          style={{ scrollMarginTop: 132, minWidth: 0 }}
+        >
+          {child}
+        </div>
+      );
+    });
+
+    if (anchored.length === 1) {
+      return anchored[0];
     }
     return (
       <Space direction="vertical" style={{ width: "100%" }} size={16}>
-        {children}
+        {anchored}
       </Space>
     );
   }

--- a/web/src/pages/contact/ContactDetail.tsx
+++ b/web/src/pages/contact/ContactDetail.tsx
@@ -238,12 +238,14 @@ const COMPACT_SECTION_ANCHOR_MARGIN = 188;
 // placeholder height as the viewport passes them, moving the target. Once the
 // animation goes quiet, re-assert the destination if it drifted; give up after
 // a few seconds rather than fight a reader who has scrolled on.
-function settleIntoView(node: HTMLElement) {
+function settleIntoView(node: HTMLElement, isCurrent: () => boolean) {
+  if (!isCurrent()) return;
   node.scrollIntoView({ behavior: "smooth", block: "start" });
   let lastY = Number.NaN;
   let quietFrames = 0;
   let frames = 0;
   const watch = () => {
+    if (!isCurrent()) return;
     if (frames++ > 240) return;
     const y = window.scrollY;
     quietFrames = y === lastY ? quietFrames + 1 : 0;
@@ -365,6 +367,10 @@ function ContactSectionLayout({
   const screens = Grid.useBreakpoint();
   const containerRef = useRef<HTMLDivElement>(null);
   const scrolledTargetRef = useRef<string | null>(null);
+  // Every navigation supersedes the previous one. This token stops an older
+  // lazy-module wait or scroll-settling watcher from snapping the page back
+  // after the reader has already selected a different destination.
+  const navigationRequestRef = useRef(0);
   const [activeSectionKey, setActiveSectionKey] = useState<string | null>(null);
   const [loadedSectionKeys, setLoadedSectionKeys] = useState<
     ReadonlySet<string>
@@ -412,25 +418,30 @@ function ContactSectionLayout({
   };
 
   const jumpToSection = (key: string) => {
+    const requestID = ++navigationRequestRef.current;
     openSection(key);
     const section = getSectionNodes().find(
       (node) => node.dataset.contactSectionKey === key,
     );
-    if (section) settleIntoView(section);
+    if (section) {
+      settleIntoView(section, () => navigationRequestRef.current === requestID);
+    }
   };
 
   // Scrolls to one card within a section. Sections below the fold are not
   // rendered until they are needed, so the card may not exist yet — hence the
   // few frames of grace before giving up.
   const jumpToModule = (sectionKey: string, moduleKey: string) => {
+    const requestID = ++navigationRequestRef.current;
     openSection(sectionKey);
     let attempts = 0;
     const scrollWhenReady = () => {
+      if (navigationRequestRef.current !== requestID) return;
       const node = containerRef.current?.querySelector<HTMLElement>(
         `[data-contact-module-key="${moduleKey}"]`,
       );
       if (node) {
-        settleIntoView(node);
+        settleIntoView(node, () => navigationRequestRef.current === requestID);
         return;
       }
       if (attempts++ < 10) requestAnimationFrame(scrollWhenReady);
@@ -505,6 +516,7 @@ function ContactSectionLayout({
       (node) => node.dataset.contactSectionKey === targetSectionKey,
     );
     if (!section) return;
+    navigationRequestRef.current += 1;
     scrolledTargetRef.current = targetContext;
     section.scrollIntoView({ behavior: "auto", block: "start" });
   }, [getSectionNodes, sectionIdentity, targetContext, targetSectionKey]);

--- a/web/src/pages/contact/ContactDetail.tsx
+++ b/web/src/pages/contact/ContactDetail.tsx
@@ -224,6 +224,41 @@ function contactLabelAssignmentsQueryKey(vaultId: string, contactId: string) {
   return ["vaults", vaultId, "contacts", contactId, "labels"] as const;
 }
 
+// How far a jumped-to anchor must stay below the viewport top: past the app
+// header and vault nav (116px) plus breathing room. In compact mode the sticky
+// section Select (8px padding + 32px control + 12px padding, from 116) also
+// stands over the content, so anchors must clear its bottom edge at 168px too
+// — an anchor at 132 would put the heading underneath it.
+const SECTION_ANCHOR_MARGIN = 132;
+const COMPACT_SECTION_ANCHOR_MARGIN = 176;
+
+// Smooth scrolling aims at where the target was when the animation started,
+// but lazily-mounted sections between here and there inflate from their
+// placeholder height as the viewport passes them, moving the target. Once the
+// animation goes quiet, re-assert the destination if it drifted; give up after
+// a few seconds rather than fight a reader who has scrolled on.
+function settleIntoView(node: HTMLElement) {
+  node.scrollIntoView({ behavior: "smooth", block: "start" });
+  let lastY = Number.NaN;
+  let quietFrames = 0;
+  let frames = 0;
+  const watch = () => {
+    if (frames++ > 240) return;
+    const y = window.scrollY;
+    quietFrames = y === lastY ? quietFrames + 1 : 0;
+    lastY = y;
+    if (quietFrames < 3) {
+      requestAnimationFrame(watch);
+      return;
+    }
+    const margin = parseFloat(getComputedStyle(node).scrollMarginTop) || 0;
+    if (Math.abs(node.getBoundingClientRect().top - margin) > 4) {
+      node.scrollIntoView({ behavior: "auto", block: "start" });
+    }
+  };
+  requestAnimationFrame(watch);
+}
+
 function vaultLabelsQueryKey(vaultId: string) {
   return ["vaults", vaultId, "labels"] as const;
 }
@@ -380,7 +415,7 @@ function ContactSectionLayout({
     const section = getSectionNodes().find(
       (node) => node.dataset.contactSectionKey === key,
     );
-    section?.scrollIntoView({ behavior: "smooth", block: "start" });
+    if (section) settleIntoView(section);
   };
 
   // Scrolls to one card within a section. Sections below the fold are not
@@ -394,7 +429,7 @@ function ContactSectionLayout({
         `[data-contact-module-key="${moduleKey}"]`,
       );
       if (node) {
-        node.scrollIntoView({ behavior: "smooth", block: "start" });
+        settleIntoView(node);
         return;
       }
       if (attempts++ < 10) requestAnimationFrame(scrollWhenReady);
@@ -622,7 +657,9 @@ function ContactSectionLayout({
               aria-labelledby={headingID}
               aria-busy={!shouldRender}
               style={{
-                scrollMarginTop: 132,
+                scrollMarginTop: compactNavigation
+                  ? COMPACT_SECTION_ANCHOR_MARGIN
+                  : SECTION_ANCHOR_MARGIN,
                 marginBottom: index === pageEntries.length - 1 ? 0 : 40,
                 minWidth: 0,
               }}
@@ -1492,7 +1529,12 @@ export default function ContactDetail() {
         <div
           key={key}
           data-contact-module-key={key}
-          style={{ scrollMarginTop: 132, minWidth: 0 }}
+          style={{
+            scrollMarginTop: detailScreens.lg
+              ? SECTION_ANCHOR_MARGIN
+              : COMPACT_SECTION_ANCHOR_MARGIN,
+            minWidth: 0,
+          }}
         >
           {child}
         </div>

--- a/web/src/pages/contact/ContactDetail.tsx
+++ b/web/src/pages/contact/ContactDetail.tsx
@@ -227,10 +227,11 @@ function contactLabelAssignmentsQueryKey(vaultId: string, contactId: string) {
 // How far a jumped-to anchor must stay below the viewport top: past the app
 // header and vault nav (116px) plus breathing room. In compact mode the sticky
 // section Select (8px padding + 32px control + 12px padding, from 116) also
-// stands over the content, so anchors must clear its bottom edge at 168px too
-// — an anchor at 132 would put the heading underneath it.
+// stands over the content, so anchors must clear its measured bottom edge
+// (~179px — the Select renders taller than its nominal 32px) with room to
+// spare; an anchor at 132 would put the heading underneath it.
 const SECTION_ANCHOR_MARGIN = 132;
-const COMPACT_SECTION_ANCHOR_MARGIN = 176;
+const COMPACT_SECTION_ANCHOR_MARGIN = 188;
 
 // Smooth scrolling aims at where the target was when the animation started,
 // but lazily-mounted sections between here and there inflate from their

--- a/web/src/pages/contact/sectionNavCards.ts
+++ b/web/src/pages/contact/sectionNavCards.ts
@@ -10,21 +10,30 @@ function normaliseNavName(value: string): string {
 /**
  * The cards the section navigation should list under a section.
  *
- * A lone card that just restates its section's name is dropped: "Activities >
+ * A LONE card that just restates its section's name is dropped: "Activities >
  * Activities" tells the reader nothing, and repeating the name puts two
  * identically labelled buttons in one navigation, which is ambiguous both to a
  * screen reader and to anything selecting by accessible name.
  *
- * Sections whose card is named differently still expand — "Summary" holding
- * "Contact summary" is worth showing. Suppressing every single-card section
- * was tried first and made the control look broken, because in a default
- * layout five of the eight sections hold exactly one card, including the one a
- * contact opens on.
+ * Only the lone case folds. In a multi-card section a card sharing the
+ * section's name is still a distinct scroll target — its siblings prove the
+ * section and the card are different things — so renaming a page to match one
+ * of its cards must not silently delete that card from the navigation.
+ *
+ * Sections whose lone card is named differently still expand — "Summary"
+ * holding "Contact summary" is worth showing. Suppressing every single-card
+ * section was tried first and made the control look broken, because in a
+ * default layout five of the eight sections hold exactly one card, including
+ * the one a contact opens on.
  */
 export function sectionNavCards(page: ContactTabPage): ContactTabModule[] {
-  const sectionName = normaliseNavName(page.name ?? page.slug ?? "");
-  return (page.modules ?? []).filter(
-    (card) => normaliseNavName(card.name ?? card.type ?? "") !== sectionName,
-  );
+  const cards = page.modules ?? [];
+  if (cards.length === 1) {
+    const sectionName = normaliseNavName(page.name ?? page.slug ?? "");
+    if (normaliseNavName(cards[0].name ?? cards[0].type ?? "") === sectionName) {
+      return [];
+    }
+  }
+  return cards;
 }
 

--- a/web/src/pages/contact/sectionNavCards.ts
+++ b/web/src/pages/contact/sectionNavCards.ts
@@ -1,0 +1,30 @@
+import type { ContactTabModule, ContactTabPage } from "@/api";
+
+// Compares a card's name with its section's for the navigation, ignoring case
+// and spacing so "Relationship network" and "Relationship Network" count as the
+// same word rather than as two entries.
+function normaliseNavName(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/**
+ * The cards the section navigation should list under a section.
+ *
+ * A lone card that just restates its section's name is dropped: "Activities >
+ * Activities" tells the reader nothing, and repeating the name puts two
+ * identically labelled buttons in one navigation, which is ambiguous both to a
+ * screen reader and to anything selecting by accessible name.
+ *
+ * Sections whose card is named differently still expand — "Summary" holding
+ * "Contact summary" is worth showing. Suppressing every single-card section
+ * was tried first and made the control look broken, because in a default
+ * layout five of the eight sections hold exactly one card, including the one a
+ * contact opens on.
+ */
+export function sectionNavCards(page: ContactTabPage): ContactTabModule[] {
+  const sectionName = normaliseNavName(page.name ?? page.slug ?? "");
+  return (page.modules ?? []).filter(
+    (card) => normaliseNavName(card.name ?? card.type ?? "") !== sectionName,
+  );
+}
+

--- a/web/src/test/Layout.test.tsx
+++ b/web/src/test/Layout.test.tsx
@@ -86,6 +86,27 @@ function renderLayout() {
   );
 }
 
+describe("Layout scrolling", () => {
+  beforeEach(() => {
+    mockUseQuery.mockReset();
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+    authState.isAdmin = false;
+  });
+
+  it("leaves the content region scrollable by the page, not by itself", () => {
+    // A scrollable ancestor becomes the containing block for position:sticky
+    // inside it. Setting overflow here silently stops the contact-section
+    // navigation from sticking to the viewport, with no error anywhere — so the
+    // absence of an overflow is worth asserting.
+    const { container } = renderLayout();
+    const content = container.querySelector(".ant-layout-content");
+    expect(content).not.toBeNull();
+
+    const overflow = (content as HTMLElement).style.overflow;
+    expect(overflow === "" || overflow === "visible").toBe(true);
+  });
+});
+
 describe("Layout vault navigation visibility", () => {
   beforeEach(() => {
     mockUseQuery.mockReset();

--- a/web/src/test/sectionNavCards.test.ts
+++ b/web/src/test/sectionNavCards.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { sectionNavCards } from "@/pages/contact/sectionNavCards";
+import type { ContactTabPage } from "@/api";
+
+const page = (name: string, cards: string[]): ContactTabPage => ({
+  id: 1,
+  name,
+  slug: name.toLowerCase(),
+  type: "contact",
+  modules: cards.map((n, i) => ({ id: i + 1, name: n, type: n.toLowerCase(), position: i })),
+});
+
+describe("sectionNavCards", () => {
+  it("lists the cards of a multi-card section", () => {
+    const cards = sectionNavCards(page("Profile and contact", ["Important dates", "Labels", "Addresses"]));
+    expect(cards.map((c) => c.name)).toEqual(["Important dates", "Labels", "Addresses"]);
+  });
+
+  it("keeps a single card whose name differs from the section", () => {
+    // "Summary" holding "Contact summary" is worth showing.
+    expect(sectionNavCards(page("Summary", ["Contact summary"])).map((c) => c.name)).toEqual([
+      "Contact summary",
+    ]);
+  });
+
+  it("drops a lone card that merely restates the section name", () => {
+    // "Activities > Activities" tells the reader nothing, and two buttons with
+    // the same accessible name in one nav are ambiguous to a screen reader.
+    expect(sectionNavCards(page("Activities", ["Activities"]))).toEqual([]);
+    expect(sectionNavCards(page("Goals", ["Goals"]))).toEqual([]);
+    expect(sectionNavCards(page("Relationship network", ["Relationship network"]))).toEqual([]);
+  });
+
+  it("ignores case and spacing when comparing", () => {
+    expect(sectionNavCards(page("Relationship network", ["Relationship  Network"]))).toEqual([]);
+  });
+
+  it("drops only the restating card, not its siblings", () => {
+    const cards = sectionNavCards(page("Social", ["Social", "Pets", "Groups"]));
+    expect(cards.map((c) => c.name)).toEqual(["Pets", "Groups"]);
+  });
+
+  it("never produces a duplicate of the section's own name", () => {
+    // The property that matters: whatever the layout, the nav cannot end up
+    // with two identically labelled buttons under one section.
+    for (const p of [
+      page("Activities", ["Activities"]),
+      page("Notes and records", ["Notes", "Documents", "Notes and records"]),
+      page("Summary", ["Contact summary"]),
+    ]) {
+      const names = sectionNavCards(p).map((c) => c.name?.toLowerCase());
+      expect(names).not.toContain(p.name?.toLowerCase());
+    }
+  });
+
+  it("handles a section with no cards", () => {
+    expect(sectionNavCards({ id: 1, name: "Empty", slug: "empty", modules: [] })).toEqual([]);
+    expect(sectionNavCards({ id: 1, name: "Empty", slug: "empty" })).toEqual([]);
+  });
+});

--- a/web/src/test/sectionNavCards.test.ts
+++ b/web/src/test/sectionNavCards.test.ts
@@ -35,21 +35,23 @@ describe("sectionNavCards", () => {
     expect(sectionNavCards(page("Relationship network", ["Relationship  Network"]))).toEqual([]);
   });
 
-  it("drops only the restating card, not its siblings", () => {
+  it("keeps a name-sharing card when it has siblings", () => {
+    // With siblings present, the section and the card are demonstrably
+    // different things, and the card is a distinct scroll target: renaming a
+    // page to match one of its cards must not silently delete that card.
     const cards = sectionNavCards(page("Social", ["Social", "Pets", "Groups"]));
-    expect(cards.map((c) => c.name)).toEqual(["Pets", "Groups"]);
+    expect(cards.map((c) => c.name)).toEqual(["Social", "Pets", "Groups"]);
   });
 
-  it("never produces a duplicate of the section's own name", () => {
-    // The property that matters: whatever the layout, the nav cannot end up
-    // with two identically labelled buttons under one section.
+  it("only ever folds the lone-card case", () => {
+    // The fold exists to stop "Activities > Activities" — a nav entry that
+    // duplicates its own section header and nothing else. Any layout with
+    // more than one card keeps every card.
     for (const p of [
-      page("Activities", ["Activities"]),
       page("Notes and records", ["Notes", "Documents", "Notes and records"]),
-      page("Summary", ["Contact summary"]),
+      page("Social", ["Social", "Pets"]),
     ]) {
-      const names = sectionNavCards(p).map((c) => c.name?.toLowerCase());
-      expect(names).not.toContain(p.name?.toLowerCase());
+      expect(sectionNavCards(p)).toHaveLength(p.modules?.length ?? 0);
     }
   });
 


### PR DESCRIPTION
Split out of #259 on review.

Two things, one of which affects the whole app.

`overflow: auto` on the layout content region made it the containing block for
every `position: sticky` descendant, so nothing anywhere could stick to the
viewport. The contact-section navigation was already declared sticky and had
simply never worked. Removing the overflow fixes it; wide content already
scrolls in its own containers.

The section list now also expands the section being read into the cards it
holds, so a reader can jump straight to Addresses rather than to the top of the
page containing it. A lone card that merely restates its section's name is left
out: "Activities › Activities" says nothing, and repeating the name would put
two identically labelled buttons in one navigation, which is ambiguous to a
screen reader and to anything selecting by accessible name.

Suppressing every single-card section was tried first and was worse — in a
default layout five of the eight sections hold one card, including the one a
contact opens on, so the control looked broken more often than not.

The rule is a pure function in its own module rather than inline JSX, both so it
can be tested and because a component file may only export components.
