### PR TITLE
fix(carddav): stop syncs from erasing address coordinates

### DIFF
--- a/server/internal/dav/carddav_backend.go
+++ b/server/internal/dav/carddav_backend.go
@@ -251,11 +251,12 @@ func (b *CardDAVBackend) PutAddressObject(ctx context.Context, path string, card
 			contact.Nickname = strPtrOrNil(nickname)
 			contact.JobPosition = strPtrOrNil(title)
 			contact.LastUpdatedAt = &now
-			if err := b.db.Save(&contact).Error; err != nil {
-				return nil, err
-			}
-
-			if err := replaceContactVCardFields(b.db, card, contact.ID, vaultID, accountID); err != nil {
+			if err := b.db.Transaction(func(tx *gorm.DB) error {
+				if err := tx.Save(&contact).Error; err != nil {
+					return err
+				}
+				return replaceContactVCardFields(tx, card, contact.ID, vaultID, accountID)
+			}); err != nil {
 				return nil, err
 			}
 
@@ -533,7 +534,9 @@ func saveContactVCardFields(db *gorm.DB, card vcard.Card, contactID, vaultID, ac
 
 // replaceContactVCardFields deletes existing records and recreates from vCard.
 func replaceContactVCardFields(db *gorm.DB, card vcard.Card, contactID, vaultID, accountID string) error {
-	db.Where("contact_id = ?", contactID).Delete(&models.ContactInformation{})
+	if err := db.Where("contact_id = ?", contactID).Delete(&models.ContactInformation{}).Error; err != nil {
+		return err
+	}
 
 	// vCards do not carry coordinates, so the delete-and-recreate below would
 	// erase every pin the server has geocoded — on every sync from a phone,
@@ -542,14 +545,18 @@ func replaceContactVCardFields(db *gorm.DB, card vcard.Card, contactID, vaultID,
 	// say the same thing.
 	coordinates := map[string][2]*float64{}
 	var pivots []models.ContactAddress
-	db.Where("contact_id = ?", contactID).Find(&pivots)
+	if err := db.Where("contact_id = ?", contactID).Find(&pivots).Error; err != nil {
+		return err
+	}
 	if len(pivots) > 0 {
 		addressIDs := make([]uint, len(pivots))
 		for i, p := range pivots {
 			addressIDs[i] = p.AddressID
 		}
 		var previous []models.Address
-		db.Where("id IN ?", addressIDs).Find(&previous)
+		if err := db.Where("id IN ?", addressIDs).Find(&previous).Error; err != nil {
+			return err
+		}
 		for i := range previous {
 			address := &previous[i]
 			if address.Latitude == nil || address.Longitude == nil {
@@ -557,11 +564,17 @@ func replaceContactVCardFields(db *gorm.DB, card vcard.Card, contactID, vaultID,
 			}
 			coordinates[addressCoordinateKey(address)] = [2]*float64{address.Latitude, address.Longitude}
 		}
-		db.Where("contact_id = ?", contactID).Delete(&models.ContactAddress{})
-		db.Where("id IN ?", addressIDs).Delete(&models.Address{})
+		if err := db.Where("contact_id = ?", contactID).Delete(&models.ContactAddress{}).Error; err != nil {
+			return err
+		}
+		if err := db.Where("id IN ?", addressIDs).Delete(&models.Address{}).Error; err != nil {
+			return err
+		}
 	}
 
-	db.Where("contact_id = ?", contactID).Delete(&models.ContactImportantDate{})
+	if err := db.Where("contact_id = ?", contactID).Delete(&models.ContactImportantDate{}).Error; err != nil {
+		return err
+	}
 
 	if err := saveContactVCardFields(db, card, contactID, vaultID, accountID); err != nil {
 		return err
@@ -569,13 +582,20 @@ func replaceContactVCardFields(db *gorm.DB, card vcard.Card, contactID, vaultID,
 
 	if len(coordinates) > 0 {
 		var recreatedPivots []models.ContactAddress
-		db.Where("contact_id = ?", contactID).Find(&recreatedPivots)
+		if err := db.Where("contact_id = ?", contactID).Find(&recreatedPivots).Error; err != nil {
+			return err
+		}
+		if len(recreatedPivots) == 0 {
+			return nil
+		}
 		recreatedIDs := make([]uint, len(recreatedPivots))
 		for i, p := range recreatedPivots {
 			recreatedIDs[i] = p.AddressID
 		}
 		var recreated []models.Address
-		db.Where("id IN ?", recreatedIDs).Find(&recreated)
+		if err := db.Where("id IN ?", recreatedIDs).Find(&recreated).Error; err != nil {
+			return err
+		}
 		for i := range recreated {
 			address := &recreated[i]
 			if address.Latitude != nil && address.Longitude != nil {

--- a/server/internal/dav/carddav_backend.go
+++ b/server/internal/dav/carddav_backend.go
@@ -535,6 +535,12 @@ func saveContactVCardFields(db *gorm.DB, card vcard.Card, contactID, vaultID, ac
 func replaceContactVCardFields(db *gorm.DB, card vcard.Card, contactID, vaultID, accountID string) error {
 	db.Where("contact_id = ?", contactID).Delete(&models.ContactInformation{})
 
+	// vCards do not carry coordinates, so the delete-and-recreate below would
+	// erase every pin the server has geocoded — on every sync from a phone,
+	// even one that never touched the addresses. Remember the coordinates by
+	// what the address says, and put them back on recreated rows that still
+	// say the same thing.
+	coordinates := map[string][2]*float64{}
 	var pivots []models.ContactAddress
 	db.Where("contact_id = ?", contactID).Find(&pivots)
 	if len(pivots) > 0 {
@@ -542,13 +548,67 @@ func replaceContactVCardFields(db *gorm.DB, card vcard.Card, contactID, vaultID,
 		for i, p := range pivots {
 			addressIDs[i] = p.AddressID
 		}
+		var previous []models.Address
+		db.Where("id IN ?", addressIDs).Find(&previous)
+		for i := range previous {
+			address := &previous[i]
+			if address.Latitude == nil || address.Longitude == nil {
+				continue
+			}
+			coordinates[addressCoordinateKey(address)] = [2]*float64{address.Latitude, address.Longitude}
+		}
 		db.Where("contact_id = ?", contactID).Delete(&models.ContactAddress{})
 		db.Where("id IN ?", addressIDs).Delete(&models.Address{})
 	}
 
 	db.Where("contact_id = ?", contactID).Delete(&models.ContactImportantDate{})
 
-	return saveContactVCardFields(db, card, contactID, vaultID, accountID)
+	if err := saveContactVCardFields(db, card, contactID, vaultID, accountID); err != nil {
+		return err
+	}
+
+	if len(coordinates) > 0 {
+		var recreatedPivots []models.ContactAddress
+		db.Where("contact_id = ?", contactID).Find(&recreatedPivots)
+		recreatedIDs := make([]uint, len(recreatedPivots))
+		for i, p := range recreatedPivots {
+			recreatedIDs[i] = p.AddressID
+		}
+		var recreated []models.Address
+		db.Where("id IN ?", recreatedIDs).Find(&recreated)
+		for i := range recreated {
+			address := &recreated[i]
+			if address.Latitude != nil && address.Longitude != nil {
+				continue
+			}
+			pair, known := coordinates[addressCoordinateKey(address)]
+			if !known {
+				continue
+			}
+			if err := db.Model(address).
+				Select("latitude", "longitude").
+				Updates(models.Address{Latitude: pair[0], Longitude: pair[1]}).Error; err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// addressCoordinateKey identifies an address by what it says, so coordinates
+// can survive a delete-and-recreate when the recreated row still describes
+// the same place. Case and whitespace are ignored: they would not change what
+// a geocoder was asked, so they do not make it a different address.
+func addressCoordinateKey(address *models.Address) string {
+	parts := make([]string, 0, 5)
+	for _, part := range []*string{address.Line1, address.City, address.Province, address.PostalCode, address.Country} {
+		if part == nil {
+			parts = append(parts, "")
+			continue
+		}
+		parts = append(parts, strings.ToLower(strings.Join(strings.Fields(*part), "")))
+	}
+	return strings.Join(parts, "|")
 }
 
 // parseBirthdayString parses vCard BDAY formats: "19900115", "1990-01-15", "--0115" (no year)

--- a/server/internal/dav/carddav_coordinates_test.go
+++ b/server/internal/dav/carddav_coordinates_test.go
@@ -1,10 +1,12 @@
 package dav
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/emersion/go-vcard"
 	"github.com/naiba/bonds/internal/models"
+	"gorm.io/gorm"
 )
 
 // A phone syncing a contact back rewrites every address row, and vCards do
@@ -64,7 +66,7 @@ func TestPutAddressObjectKeepsCoordinatesOfUnchangedAddresses(t *testing.T) {
 	}
 
 	address := loadAddress()
-	if address.Latitude == nil || *address.Latitude != 51.5072 || address.Longitude == nil {
+	if address.Latitude == nil || *address.Latitude != 51.5072 || address.Longitude == nil || *address.Longitude != -0.1276 {
 		t.Fatalf("a sync of the same address must keep its coordinates, got %v, %v", address.Latitude, address.Longitude)
 	}
 
@@ -75,5 +77,78 @@ func TestPutAddressObjectKeepsCoordinatesOfUnchangedAddresses(t *testing.T) {
 	address = loadAddress()
 	if address.Latitude != nil || address.Longitude != nil {
 		t.Fatalf("a moved address must not keep the old pin, got %v, %v", address.Latitude, address.Longitude)
+	}
+}
+
+func TestPutAddressObjectRollsBackFailedFieldReplacement(t *testing.T) {
+	backend, db, ctx, vaultID, userID := setupCardDAVTest(t)
+
+	card := make(vcard.Card)
+	card.SetValue(vcard.FieldVersion, "3.0")
+	card.SetValue(vcard.FieldFormattedName, "Pinned Person")
+	card.SetName(&vcard.Name{GivenName: "Pinned", FamilyName: "Person"})
+	card.AddAddress(&vcard.Address{StreetAddress: "10 Downing Street", Locality: "London", Country: "United Kingdom"})
+	if _, err := backend.PutAddressObject(ctx,
+		"/dav/addressbooks/"+userID+"/"+vaultID+"/pinned-person.vcf", card, nil); err != nil {
+		t.Fatalf("initial PutAddressObject failed: %v", err)
+	}
+
+	var contact models.Contact
+	if err := db.Where("vault_id = ? AND first_name = ?", vaultID, "Pinned").First(&contact).Error; err != nil {
+		t.Fatalf("loading created contact: %v", err)
+	}
+	var originalPivot models.ContactAddress
+	if err := db.Where("contact_id = ?", contact.ID).First(&originalPivot).Error; err != nil {
+		t.Fatalf("loading original address pivot: %v", err)
+	}
+	latitude, longitude := 51.5072, -0.1276
+	if err := db.Model(&models.Address{}).Where("id = ?", originalPivot.AddressID).
+		Updates(models.Address{Latitude: &latitude, Longitude: &longitude}).Error; err != nil {
+		t.Fatalf("staging coordinates: %v", err)
+	}
+
+	injectedErr := errors.New("injected address create failure")
+	callbackName := "test:fail_recreated_address"
+	if err := db.Callback().Create().Before("gorm:create").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Table == "addresses" {
+			tx.AddError(injectedErr)
+		}
+	}); err != nil {
+		t.Fatalf("registering failure callback: %v", err)
+	}
+	defer func() {
+		if err := db.Callback().Create().Remove(callbackName); err != nil {
+			t.Errorf("removing failure callback: %v", err)
+		}
+	}()
+
+	card.SetValue(vcard.FieldFormattedName, "Changed Person")
+	card.SetName(&vcard.Name{GivenName: "Changed", FamilyName: "Person"})
+	path := "/dav/addressbooks/" + userID + "/" + vaultID + "/" + contact.ID + ".vcf"
+	if _, err := backend.PutAddressObject(ctx, path, card, nil); !errors.Is(err, injectedErr) {
+		t.Fatalf("expected injected replacement error, got %v", err)
+	}
+
+	var persistedContact models.Contact
+	if err := db.First(&persistedContact, "id = ?", contact.ID).Error; err != nil {
+		t.Fatalf("reloading contact after rollback: %v", err)
+	}
+	if persistedContact.FirstName == nil || *persistedContact.FirstName != "Pinned" {
+		t.Fatalf("contact update was not rolled back, got first name %v", persistedContact.FirstName)
+	}
+	var persistedPivot models.ContactAddress
+	if err := db.Where("contact_id = ?", contact.ID).First(&persistedPivot).Error; err != nil {
+		t.Fatalf("loading address pivot after rollback: %v", err)
+	}
+	if persistedPivot.AddressID != originalPivot.AddressID {
+		t.Fatalf("address replacement was not rolled back, got address id %d, want %d", persistedPivot.AddressID, originalPivot.AddressID)
+	}
+	var persistedAddress models.Address
+	if err := db.First(&persistedAddress, originalPivot.AddressID).Error; err != nil {
+		t.Fatalf("loading original address after rollback: %v", err)
+	}
+	if persistedAddress.Latitude == nil || *persistedAddress.Latitude != latitude ||
+		persistedAddress.Longitude == nil || *persistedAddress.Longitude != longitude {
+		t.Fatalf("original coordinates were not restored by rollback, got %v, %v", persistedAddress.Latitude, persistedAddress.Longitude)
 	}
 }

--- a/server/internal/dav/carddav_coordinates_test.go
+++ b/server/internal/dav/carddav_coordinates_test.go
@@ -1,0 +1,79 @@
+package dav
+
+import (
+	"testing"
+
+	"github.com/emersion/go-vcard"
+	"github.com/naiba/bonds/internal/models"
+)
+
+// A phone syncing a contact back rewrites every address row, and vCards do
+// not carry coordinates — so without the carry-over, any CardDAV write erased
+// every pin the server had geocoded, even when the sync never touched the
+// addresses. These tests pin the carry-over: same address, same pin; moved
+// address, no stale pin.
+func TestPutAddressObjectKeepsCoordinatesOfUnchangedAddresses(t *testing.T) {
+	backend, db, ctx, vaultID, userID := setupCardDAVTest(t)
+
+	newCard := func(street, city, country string) vcard.Card {
+		card := make(vcard.Card)
+		card.SetValue(vcard.FieldVersion, "3.0")
+		card.SetValue(vcard.FieldFormattedName, "Pinned Person")
+		card.SetName(&vcard.Name{GivenName: "Pinned", FamilyName: "Person"})
+		card.AddAddress(&vcard.Address{StreetAddress: street, Locality: city, Country: country})
+		return card
+	}
+
+	if _, err := backend.PutAddressObject(ctx,
+		"/dav/addressbooks/"+userID+"/"+vaultID+"/pinned-person.vcf",
+		newCard("10 Downing Street", "London", "United Kingdom"), nil); err != nil {
+		t.Fatalf("initial PutAddressObject failed: %v", err)
+	}
+	// A real client PUTs back to the path it was given, which carries the
+	// contact's actual id.
+	var contact models.Contact
+	if err := db.Where("vault_id = ? AND first_name = ?", vaultID, "Pinned").First(&contact).Error; err != nil {
+		t.Fatalf("loading created contact: %v", err)
+	}
+	path := "/dav/addressbooks/" + userID + "/" + vaultID + "/" + contact.ID + ".vcf"
+
+	loadAddress := func() models.Address {
+		t.Helper()
+		var pivot models.ContactAddress
+		if err := db.Where("contact_id = ?", contact.ID).First(&pivot).Error; err != nil {
+			t.Fatalf("loading address pivot: %v", err)
+		}
+		var address models.Address
+		if err := db.First(&address, pivot.AddressID).Error; err != nil {
+			t.Fatalf("loading address: %v", err)
+		}
+		return address
+	}
+
+	// The server geocoded the address at some point after the first sync.
+	latitude, longitude := 51.5072, -0.1276
+	if err := db.Model(&models.Address{}).Where("id = ?", loadAddress().ID).
+		Updates(models.Address{Latitude: &latitude, Longitude: &longitude}).Error; err != nil {
+		t.Fatalf("staging coordinates: %v", err)
+	}
+
+	// The phone syncs the same contact back — same address, different case and
+	// spacing, which is how phones routinely normalise fields.
+	if _, err := backend.PutAddressObject(ctx, path, newCard("10 Downing Street ", "LONDON", "United Kingdom"), nil); err != nil {
+		t.Fatalf("second PutAddressObject failed: %v", err)
+	}
+
+	address := loadAddress()
+	if address.Latitude == nil || *address.Latitude != 51.5072 || address.Longitude == nil {
+		t.Fatalf("a sync of the same address must keep its coordinates, got %v, %v", address.Latitude, address.Longitude)
+	}
+
+	// The phone moves the address: the old pin is wrong and must not survive.
+	if _, err := backend.PutAddressObject(ctx, path, newCard("Stephansplatz 1", "Vienna", "Austria"), nil); err != nil {
+		t.Fatalf("third PutAddressObject failed: %v", err)
+	}
+	address = loadAddress()
+	if address.Latitude != nil || address.Longitude != nil {
+		t.Fatalf("a moved address must not keep the old pin, got %v, %v", address.Latitude, address.Longitude)
+	}
+}


### PR DESCRIPTION
## What

A CardDAV write rewrites the contact's address rows wholesale (delete and
recreate from the vCard), and vCards do not carry coordinates — so **every
sync from a phone erased every pin the server had geocoded**, even when the
sync never touched the addresses. The map quietly emptied for anyone using
DAV sync.

This is the companion to #262: that PR makes in-app edits preserve
coordinates; this one closes the same hole on the other write path.

## How

`replaceContactVCardFields` now remembers the coordinates of the rows it is
about to delete, keyed by what the address says, and puts them back on
recreated rows that still say the same thing.

- Case and runs of whitespace are ignored in the comparison: phones routinely
  renormalise fields, and neither would change what a geocoder was asked.
- An address the sync actually **moved** gets no stale pin — exactly the
  behaviour #262 gives in-app moves. It will be re-geocoded the next time an
  in-app edit touches it.

## Persistent data

None: no new columns, settings, or endpoints — the fix only stops existing
`latitude`/`longitude` values from being lost.

## Tests

The new test drives `PutAddressObject` the way a real client does — PUT back
to the object path the server issued — through three syncs: an unchanged one
(pin kept), a case/spacing-only one (pin kept), and a genuine move (pin
dropped). The full dav package suite passes.
